### PR TITLE
OKTA-221606-OIDC iOS: Keychain read with long keys fails

### DIFF
--- a/Example/Okta/AppDelegate.swift
+++ b/Example/Okta/AppDelegate.swift
@@ -1,10 +1,14 @@
-//
-//  AppDelegate.swift
-//  Okta
-//
-//  Created by jmelberg on 06/17/2017.
-//  Copyright (c) 2017 jmelberg. All rights reserved.
-//
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
 
 import UIKit
 import OktaOidc

--- a/Example/Okta/AuthViewController.swift
+++ b/Example/Okta/AuthViewController.swift
@@ -1,10 +1,14 @@
-//
-//  AuthViewController.swift
-//  Okta_Example
-//
-//  Created by Anastasiia Iurok on 1/11/19.
-//  Copyright © 2019 Okta. All rights reserved.
-//
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
 
 import UIKit
 import OktaOidc

--- a/Example/Okta/ViewController.swift
+++ b/Example/Okta/ViewController.swift
@@ -1,10 +1,14 @@
-//
-//  ViewController.swift
-//  Okta
-//
-//  Created by jmelberg on 06/17/2017.
-//  Copyright (c) 2017 jmelberg. All rights reserved.
-//
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
 
 import UIKit
 import OktaOidc

--- a/Example/Okta_UITests/Okta_UITests.swift
+++ b/Example/Okta_UITests/Okta_UITests.swift
@@ -177,6 +177,6 @@ class OktaUITests: XCTestCase {
             return
         }
         
-        XCTAssertTrue(errorDescription.contains(OktaOidcError.unableToGetAuthCode.localizedDescription))
+        XCTAssertTrue(errorDescription.contains("Authorization Error"))
     }
 }

--- a/Example/Tests/OktaOidcConfigTests.swift
+++ b/Example/Tests/OktaOidcConfigTests.swift
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
 import XCTest
 @testable import OktaOidc
 

--- a/Example/Tests/OktaOidcDiscoveryTaskTests.swift
+++ b/Example/Tests/OktaOidcDiscoveryTaskTests.swift
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
 import XCTest
 @testable import OktaOidc
 

--- a/Example/Tests/OktaOidcEndpointTests.swift
+++ b/Example/Tests/OktaOidcEndpointTests.swift
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
 import XCTest
 
 @testable import OktaOidc

--- a/Example/Tests/OktaOidcKeychainTests.swift
+++ b/Example/Tests/OktaOidcKeychainTests.swift
@@ -1,10 +1,14 @@
-//
-//  OktaKeychainTests.swift
-//  Okta_Example
-//
-//  Created by Alex on 20 Feb 19.
-//  Copyright © 2019 Okta. All rights reserved.
-//
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
 
 import XCTest
 @testable import OktaOidc

--- a/Example/Tests/OktaOidcTests.swift
+++ b/Example/Tests/OktaOidcTests.swift
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
 import XCTest
 @testable import OktaOidc
 

--- a/Example/Tests/OktaOidcUtilsTests.swift
+++ b/Example/Tests/OktaOidcUtilsTests.swift
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
 import XCTest
 @testable import OktaOidc
 

--- a/Example/Tests/TestUtils.swift
+++ b/Example/Tests/TestUtils.swift
@@ -1,10 +1,14 @@
-//
-//  TestUtils.swift
-//  Okta_Example
-//
-//  Created by Jordan Melberg on 3/13/18.
-//  Copyright © 2018 Okta. All rights reserved.
-//
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
 
 @testable import OktaOidc
 
@@ -26,10 +30,10 @@ struct TestUtils {
         "pu1WrZzuBHoQXuDkuYH6xKbKU2bopZGnA8PwrsIbr6PmmTaeH5ww0Q"
     static let mockRefreshToken = "mockRefreshToken"
 
-    static var authStateManager = { return TestUtils.setupMockAuthStateManager(issuer: mockIssuer) }
-    static var authStateManagerWithExpiration = { return TestUtils.setupMockAuthStateManager(issuer: mockIssuer, expiresIn: 5) }
+    static var authStateManager = { return TestUtils.setupMockAuthStateManager(issuer: mockIssuer, clientId: mockClientId) }
+    static var authStateManagerWithExpiration = { return TestUtils.setupMockAuthStateManager(issuer: mockIssuer, clientId: mockClientId, expiresIn: 5) }
     
-    static func setupMockAuthState(issuer: String, expiresIn: TimeInterval = 300) -> OIDAuthState {
+    static func setupMockAuthState(issuer: String, clientId: String, expiresIn: TimeInterval = 300) -> OIDAuthState {
         // Creates a mock Okta Auth State Manager object
         let fooURL = URL(string: issuer)!
         let mockServiceConfig = OIDServiceConfiguration(authorizationEndpoint: fooURL, tokenEndpoint: fooURL, issuer: fooURL)
@@ -49,7 +53,7 @@ struct TestUtils {
 
         let mockAuthRequest = OIDAuthorizationRequest(
                    configuration: mockServiceConfig,
-                        clientId: mockClientId,
+                        clientId: clientId,
                     clientSecret: nil,
                           scopes: ["openid", "email"],
                      redirectURL: fooURL,
@@ -78,8 +82,8 @@ struct TestUtils {
     }
 
 
-    static func setupMockAuthStateManager(issuer: String, expiresIn: TimeInterval = 300) -> OktaOidcStateManager {
-        let tempAuthState = setupMockAuthState(issuer: issuer, expiresIn: expiresIn)
+    static func setupMockAuthStateManager(issuer: String, clientId: String, expiresIn: TimeInterval = 300) -> OktaOidcStateManager {
+        let tempAuthState = setupMockAuthState(issuer: issuer, clientId: clientId, expiresIn: expiresIn)
         return OktaOidcStateManager(authState: tempAuthState)
     }
 }

--- a/Okta/OktaOidc/OktaOidcStateManager.swift
+++ b/Okta/OktaOidc/OktaOidcStateManager.swift
@@ -164,7 +164,12 @@ public extension OktaOidcStateManager {
             return clientId
         }
         
-        return issuer + "_" + clientId
+        var key = issuer + "_" + clientId
+        key = Data(key.utf8).base64EncodedString()
+        if key.lengthOfBytes(using: .utf8) > 40 {
+            key = String(key.prefix(20)) + String(key.suffix(20))
+        }
+        return key
     }
     
     class func readFromSecureStorage() -> OktaOidcStateManager? {


### PR DESCRIPTION
### Problem Analysis (Technical)
OKTA-221606 - OIDC iOS: Keychain read with long keys fails
https://oktainc.atlassian.net/browse/OKTA-221606

### Solution (Technical)
- Change key generation logic according to the design

### Affected Components
- Tests
- OktaOidcStateManager

### Tests
Added