### PR TITLE
Release increment - 3.1.0

### DIFF
--- a/Okta/OktaOidc/OktaOidc.swift
+++ b/Okta/OktaOidc/OktaOidc.swift
@@ -15,7 +15,7 @@ import UIKit
 public class OktaOidc: NSObject {
 
     // Current version of the SDK
-    @objc public static let VERSION = "3.0.0"
+    @objc public static let VERSION = "3.1.0"
 
     // Cache Okta.plist for reference
     @objc public let configuration: OktaOidcConfig

--- a/OktaOidc.podspec
+++ b/OktaOidc.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OktaOidc'
-  s.version          = '3.0.0'
+  s.version          = '3.1.0'
   s.summary          = 'SDK to easily integrate AppAuth with Okta'
   s.description      = <<-DESC
 Integrate your native app with Okta using the AppAuth library.
@@ -13,4 +13,5 @@ Integrate your native app with Okta using the AppAuth library.
 
   s.ios.deployment_target = '9.0'
   s.source_files = 'Okta/**/*'
+  s.swift_version = '4.2'
 end

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Version](https://img.shields.io/cocoapods/v/OktaOidc.svg?style=flat)](http://cocoapods.org/pods/OktaOidc)
 [![License](https://img.shields.io/cocoapods/l/OktaOidc.svg?style=flat)](http://cocoapods.org/pods/OktaOidc)
 [![Platform](https://img.shields.io/cocoapods/p/OktaOidc.svg?style=flat)](http://cocoapods.org/pods/OktaOidc)
+[![Swift](https://img.shields.io/badge/swift-4.2-orange.svg?style=flat)](https://developer.apple.com/swift/)
 
 # Okta Open ID Connect Library
 


### PR DESCRIPTION
Delta:
OKTA-221606-OIDC iOS: Keychain read with long keys fails - [`4a5b5ce`](https://github.com/okta/okta-oidc-ios/commit/4a5b5ce2ca351303357fcdf533b334a669df4665)

Addresses:
https://github.com/okta/okta-oidc-ios/issues/137