### PR TITLE
OKTA-237857 - iOS OIDC SDK: Callbacks for error cases are called in a…

### DIFF
--- a/Okta/OktaOidc/OktaOidcRestApi.swift
+++ b/Okta/OktaOidc/OktaOidcRestApi.swift
@@ -107,12 +107,16 @@ class OktaOidcRestApi: OktaOidcHttpApiProtocol {
         let task = URLSession.shared.dataTask(with: request){ data, response, error in
             guard let data = data, error == nil else {
                 let errorMessage = error != nil ? error!.localizedDescription : "No response data"
+                DispatchQueue.main.async {
                     onError(OktaOidcError.APIError(errorMessage))
-                    return
+                }
+                return
             }
             
             let responseJson = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) as! [String: Any]
-            onSuccess(responseJson)
+            DispatchQueue.main.async {
+                onSuccess(responseJson)
+            }
         }
         task.resume()
     }

--- a/Okta/OktaOidc/OktaOidcStateManager.swift
+++ b/Okta/OktaOidc/OktaOidcStateManager.swift
@@ -147,7 +147,9 @@ open class OktaOidcStateManager: NSObject, NSCoding {
     
     @objc public func getUser(_ callback: @escaping ([String:Any]?, Error?) -> Void) {
         guard let token = accessToken else {
-            callback(nil, OktaOidcError.noBearerToken)
+            DispatchQueue.main.async {
+                callback(nil, OktaOidcError.noBearerToken)
+            }
             return
         }
 
@@ -213,7 +215,9 @@ private extension OktaOidcStateManager {
                         token: String?,
                         callback: @escaping ([String : Any]?, OktaOidcError?) -> Void) {
         guard let token = token else {
-            callback(nil, OktaOidcError.noBearerToken)
+            DispatchQueue.main.async {
+                callback(nil, OktaOidcError.noBearerToken)
+            }
             return
         }
         
@@ -227,7 +231,9 @@ private extension OktaOidcStateManager {
                         postString: String? = nil,
                         callback: @escaping ([String : Any]?, OktaOidcError?) -> Void) {
         guard let endpointURL = endpoint.getURL(discoveredMetadata: discoveryDictionary, issuer: issuer) else {
-            callback(nil, endpoint.noEndpointError)
+            DispatchQueue.main.async {
+                callback(nil, endpoint.noEndpointError)
+            }
             return
         }
         

--- a/Okta/OktaOidc/Tasks/OktaOidcMetadataDiscovery.swift
+++ b/Okta/OktaOidc/Tasks/OktaOidcMetadataDiscovery.swift
@@ -14,10 +14,12 @@ class OktaOidcMetadataDiscovery: OktaOidcTask<OIDServiceConfiguration> {
 
     override func run(callback: @escaping (OIDServiceConfiguration?, OktaOidcError?) -> Void) {
         guard let configUrl = URL(string: "\(config.issuer)/.well-known/openid-configuration") else {
-              callback(nil, OktaOidcError.noDiscoveryEndpoint)
-              return
+            DispatchQueue.main.async {
+                callback(nil, OktaOidcError.noDiscoveryEndpoint)
+            }
+            return
         }
-        
+
         oktaAPI.get(configUrl, headers: nil, onSuccess: { response in
             guard let dictResponse = response, let oidConfig = try? OIDServiceDiscovery(dictionary: dictResponse) else {
                 callback(nil, OktaOidcError.parseFailure)


### PR DESCRIPTION
… background thread

Call user's callbacks in main thread, similar how underlaying AppAuth does