### PR TITLE
Issue 168: OktaOidcMetadataDiscovery.run() doesn't surface errors gen…

### DIFF
--- a/Okta/OktaOidc/OktaOidc.swift
+++ b/Okta/OktaOidc/OktaOidc.swift
@@ -21,11 +21,11 @@ public class OktaOidc: NSObject {
     private var currentUserSessionTask: OktaOidcUserSessionTask?
     
     @objc public init(configuration: OktaOidcConfig? = nil) throws {
-        guard let config = configuration ?? (try? OktaOidcConfig.default()) else {
-            throw OktaOidcError.notConfigured
+        if let config = configuration {
+            self.configuration = config
+        } else {
+            self.configuration = try OktaOidcConfig.default()
         }
-        
-        self.configuration = config
     }
 
     @objc public func signInWithBrowser(from presenter: UIViewController,

--- a/Okta/OktaOidc/OktaOidcConfig.swift
+++ b/Okta/OktaOidc/OktaOidcConfig.swift
@@ -26,9 +26,9 @@ public class OktaOidcConfig: NSObject, Codable {
     }
 
     @objc public init(with dict: [String: String]) throws {
-        guard let clientId = dict["clientId"],
-              let issuer = dict["issuer"],
-              let scopes = dict["scopes"],
+        guard let clientId = dict["clientId"], clientId.count > 0,
+              let issuer = dict["issuer"], let _ = URL(string: issuer),
+              let scopes = dict["scopes"], scopes.count > 0,
               let redirectUriString = dict["redirectUri"],
               let redirectUri = URL(string: redirectUriString) else {
                 throw OktaOidcError.missingConfigurationValues

--- a/Tests/OktaOidcConfigTests.swift
+++ b/Tests/OktaOidcConfigTests.swift
@@ -67,6 +67,50 @@ class OktaOidcConfigTests: XCTestCase {
         XCTAssertEqual(1, config.additionalParams?.count)
         XCTAssertEqual("test_param", config.additionalParams?["additionalParam"])
     }
+
+    func testCreationWithInvalidConfig() {
+        var dict = [
+            "clientId" : "test_client_id",
+            "issuer" : "",
+            "scopes" : "test_scope",
+            "redirectUri" : "com.test:/callback"
+        ]
+
+        do {
+            let _ = try OktaOidcConfig(with: dict)
+        } catch let error {
+            XCTAssertTrue(error.localizedDescription == OktaOidcError.missingConfigurationValues.errorDescription)
+            return
+        }
+
+        dict = [
+            "clientId" : "",
+            "issuer" : "http://www.test.com",
+            "scopes" : "test_scope",
+            "redirectUri" : "com.test:/callback"
+        ]
+        
+        do {
+            let _ = try OktaOidcConfig(with: dict)
+        } catch let error {
+            XCTAssertTrue(error.localizedDescription == OktaOidcError.missingConfigurationValues.errorDescription)
+            return
+        }
+
+        dict = [
+            "clientId" : "test_client_id",
+            "issuer" : "http://www.test.com",
+            "scopes" : "test_scope",
+            "redirectUri" : ""
+        ]
+        
+        do {
+            let _ = try OktaOidcConfig(with: dict)
+        } catch let error {
+            XCTAssertTrue(error.localizedDescription == OktaOidcError.missingConfigurationValues.errorDescription)
+            return
+        }
+    }
     
     func testDefaultConfig() {
         do {

--- a/Tests/OktaOidcDiscoveryTaskTests.swift
+++ b/Tests/OktaOidcDiscoveryTaskTests.swift
@@ -61,17 +61,6 @@ class OktaOidcDiscoveryTaskTests: XCTestCase {
             )
         }
     }
-
-    func testRunInvalidUrl() {
-        self.runAndWaitDiscovery(config: self.invalidConfig) { oidConfig, error in
-            XCTAssert(Thread.current.isMainThread)
-            XCTAssertNil(oidConfig)
-            XCTAssertEqual(
-                OktaOidcError.noDiscoveryEndpoint.localizedDescription,
-                error?.localizedDescription
-            )
-        }
-    }
     
     func testRunDiscoveryEndpointURL() {
         apiMock.configure(response: validOIDConfigDictionary) { request in
@@ -105,15 +94,6 @@ class OktaOidcDiscoveryTaskTests: XCTestCase {
     private var validConfig: OktaOidcConfig {
         return try! OktaOidcConfig(with: [
             "issuer" : "http://test.issuer.com/oauth2/default",
-            "clientId" : "test_client",
-            "scopes" : "test",
-            "redirectUri" : "test:/callback"
-        ])
-    }
-
-    private var invalidConfig: OktaOidcConfig {
-        return try! OktaOidcConfig(with: [
-            "issuer" : "     ",
             "clientId" : "test_client",
             "scopes" : "test",
             "redirectUri" : "test:/callback"

--- a/Tests/OktaOidcTests.swift
+++ b/Tests/OktaOidcTests.swift
@@ -39,7 +39,7 @@ class OktaOidcTests: XCTestCase {
         } else {
             XCTAssertThrowsError(try OktaOidc()) { error in
                 XCTAssertEqual(
-                    OktaOidcError.notConfigured.localizedDescription,
+                    OktaOidcError.missingConfigurationValues.localizedDescription,
                     error.localizedDescription
                 )
             }


### PR DESCRIPTION
…erated by OIDServiceDiscovery initializer

https://github.com/okta/okta-oidc-ios/issues/168