### PR TITLE
OKTA-244292-iOS OIDC SDK: UIApplication.keyWindow is deprecated in iOS13

### DIFF
--- a/Okta/AppAuth/OIDExternalUserAgentIOS.m
+++ b/Okta/AppAuth/OIDExternalUserAgentIOS.m
@@ -223,7 +223,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - ASWebAuthenticationPresentationContextProviding
 
 - (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session API_AVAILABLE(ios(13.0)){
-    return UIApplication.sharedApplication.keyWindow;
+    return _presentingViewController.view.window;
 }
 #endif
 


### PR DESCRIPTION
`UIApplication.sharedApplication.keyWindow` is deprecated
https://developer.apple.com/documentation/uikit/uiapplication/1622924-keywindow?language=objc