### PR TITLE
OKTA-253824 - iOS OIDC SDK: Introspect, revoke, refresh APIs are fail…

### DIFF
--- a/Okta/OktaOidc/OIDAuthState+Okta.swift
+++ b/Okta/OktaOidc/OIDAuthState+Okta.swift
@@ -14,11 +14,8 @@
 extension OIDAuthState {
 
     static func getState(withAuthRequest authRequest: OIDAuthorizationRequest, callback: @escaping (OIDAuthState?, OktaOidcError?) -> Void ) {
-        // setup custom URL session
-        self.setupURLSession()
         
         let finalize: ((OIDAuthState?, OktaOidcError?) -> Void) = { state, error in
-            self.restoreURLSession()
             callback(state, error)
         }
 
@@ -47,37 +44,5 @@ extension OIDAuthState {
                 finalize(authState, nil)
             })
         })
-    }
-    
-    private static func setupURLSession() {
-        /*
-         Setup auth session to block redirection because authorization request
-         implies redirection and passing authCode as a query parameter.
-        */
-        let config = URLSessionConfiguration.default
-        config.httpShouldSetCookies = false
-
-        let session = URLSession(
-            configuration: config,
-            delegate: RedirectBlockingURLSessionDelegate.shared,
-            delegateQueue: .main)
-        
-        OIDURLSessionProvider.setSession(session)
-    }
-    
-    private static func restoreURLSession() {
-        OIDURLSessionProvider.setSession(URLSession.shared)
-    }
-    
-    private class RedirectBlockingURLSessionDelegate: NSObject, URLSessionTaskDelegate {
-        
-        static let shared = RedirectBlockingURLSessionDelegate()
-        
-        private override init() { super.init() }
-    
-        public func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
-            // prevent redirect
-            completionHandler(nil)
-        }
     }
 }

--- a/Okta/OktaOidc/OktaOidcStateManager.swift
+++ b/Okta/OktaOidc/OktaOidcStateManager.swift
@@ -54,7 +54,8 @@ open class OktaOidcStateManager: NSObject, NSCoding {
     @objc public init(authState: OIDAuthState, accessibility: CFString = kSecAttrAccessibleWhenUnlockedThisDeviceOnly) {
         self.authState = authState
         self.accessibility = accessibility
-
+        OktaOidcConfig.setupURLSession()
+        
         super.init()
     }
 


### PR DESCRIPTION
… with 403 error after exchanging session token to access token

### Problem Analysis (Technical)
Latest version 3.5.1 has a regression where `authenticateWithSessionToken` method saves all cookies from backend response and this cause failures on subsequent `revoke`, `introspect` and refresh requests

### Solution (Technical)
1. Don't include cookies in REST requests
2. Provide custom URL session to achieve #1

### Affected Components
OIDC flow, OktaAuthStateManager