### PR TITLE
OKTA-309958 - [OIDC SDK] option to set prefersEphemeralWebBrowserSession

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: objective-c
-osx_image: xcode10.3
+osx_image: xcode11.5
 jobs:
   include:
     - stage: Unit tests iOS
       name: iOS
       script:
-      - xcodebuild -project okta-oidc.xcodeproj -scheme "okta-oidc-ios" -destination "platform=iOS Simulator,OS=latest,name=iPhone 8" clean test
+      - xcodebuild -project okta-oidc.xcodeproj -scheme "okta-oidc-ios" -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" clean test
     - stage: Unit tests MacOS
       name: MacOS
       script:
@@ -13,4 +13,4 @@ jobs:
     - stage: UI tests iOS
       name: iOS
       script:
-      - xcodebuild -project okta-oidc.xcodeproj -scheme "okta-oidc" -destination "platform=iOS Simulator,OS=latest,name=iPhone 8" clean test
+      - xcodebuild -project okta-oidc.xcodeproj -scheme "okta-oidc" -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" clean test

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -29,12 +29,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         return true
     }
-
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any]) -> Bool {
-        guard #available(iOS 11, *) else {
-            return oktaOidc?.resume(url, options: options) ?? false
-        }
-        
-        return false
-    }
 }

--- a/Okta/AppAuth/iOS/OIDExternalUserAgentNoSsoIOS.h
+++ b/Okta/AppAuth/iOS/OIDExternalUserAgentNoSsoIOS.h
@@ -1,0 +1,45 @@
+/*
+* Copyright (c) 2020, Okta, Inc. and/or its affiliates. All rights reserved.
+* The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+*
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+#import <UIKit/UIKit.h>
+#import <AuthenticationServices/AuthenticationServices.h>
+
+#import "OIDExternalUserAgent.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*! @brief An iOS specific external user-agent that uses the best possible user-agent available
+           for the no-SSO sessions.
+ */
+@interface OIDExternalUserAgentNoSsoIOS : NSObject<OIDExternalUserAgent>
+
+- (instancetype)init API_AVAILABLE(ios(11))
+    __deprecated_msg("This method will not work on iOS 13, use "
+                     "initWithPresentingViewController:presentingViewController");
+
+/*! @brief The designated initializer.
+    @param presentingViewController The view controller from which to present the
+        \SFSafariViewController.
+ */
+- (instancetype)initWithPresentingViewController:
+    (UIViewController *)presentingViewController
+    NS_DESIGNATED_INITIALIZER;
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+#pragma mark - ASWebAuthenticationPresentationContextProviding
+
+- (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session API_AVAILABLE(ios(13.0));
+#endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+
+NS_ASSUME_NONNULL_END
+
+@end

--- a/Okta/AppAuth/iOS/OIDExternalUserAgentNoSsoIOS.m
+++ b/Okta/AppAuth/iOS/OIDExternalUserAgentNoSsoIOS.m
@@ -1,0 +1,161 @@
+/*
+* Copyright (c) 2020, Okta, Inc. and/or its affiliates. All rights reserved.
+* The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+*
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+#import "OIDExternalUserAgentNoSsoIOS.h"
+
+#import <SafariServices/SafariServices.h>
+#import <AuthenticationServices/AuthenticationServices.h>
+
+#import "OIDErrorUtilities.h"
+#import "OIDExternalUserAgentSession.h"
+#import "OIDExternalUserAgentRequest.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+@interface OIDExternalUserAgentNoSsoIOS ()<SFSafariViewControllerDelegate, ASWebAuthenticationPresentationContextProviding>
+@end
+#else
+@interface OIDExternalUserAgentNoSsoIOS ()<SFSafariViewControllerDelegate>
+@end
+#endif
+
+@implementation OIDExternalUserAgentNoSsoIOS {
+  UIViewController *_presentingViewController;
+
+  BOOL _externalUserAgentFlowInProgress;
+  __weak id<OIDExternalUserAgentSession> _session;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+  ASWebAuthenticationSession *_webAuthenticationVC;
+#pragma clang diagnostic pop
+}
+
+- (nonnull instancetype)init {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+  return [self initWithPresentingViewController:nil];
+#pragma clang diagnostic pop
+}
+
+- (nonnull instancetype)initWithPresentingViewController:
+    (UIViewController *)presentingViewController {
+  self = [super init];
+  if (self) {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+    NSAssert(presentingViewController != nil,
+             @"presentingViewController cannot be nil on iOS 13");
+#endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+    
+    _presentingViewController = presentingViewController;
+  }
+  return self;
+}
+
+- (BOOL)presentExternalUserAgentRequest:(id<OIDExternalUserAgentRequest>)request
+                                session:(id<OIDExternalUserAgentSession>)session {
+  if (_externalUserAgentFlowInProgress) {
+    // TODO: Handle errors as authorization is already in progress.
+    return NO;
+  }
+
+  _externalUserAgentFlowInProgress = YES;
+  _session = session;
+  BOOL openedUserAgent = NO;
+  NSURL *requestURL = [request externalUserAgentRequestURL];
+
+  // iOS 13 and later, use ASWebAuthenticationSession
+  if (@available(iOS 13.0, *)) {
+    // ASWebAuthenticationSession doesn't work with guided access (rdar://40809553)
+    if (!UIAccessibilityIsGuidedAccessEnabled()) {
+      __weak OIDExternalUserAgentNoSsoIOS *weakSelf = self;
+      NSString *redirectScheme = request.redirectScheme;
+      ASWebAuthenticationSession *authenticationVC =
+          [[ASWebAuthenticationSession alloc] initWithURL:requestURL
+                                        callbackURLScheme:redirectScheme
+                                         completionHandler:^(NSURL * _Nullable callbackURL,
+                                                             NSError * _Nullable error) {
+        __strong OIDExternalUserAgentNoSsoIOS *strongSelf = weakSelf;
+        if (!strongSelf) {
+            return;
+        }
+        strongSelf->_webAuthenticationVC = nil;
+        if (callbackURL) {
+          [strongSelf->_session resumeExternalUserAgentFlowWithURL:callbackURL];
+        } else {
+          NSError *safariError =
+              [OIDErrorUtilities errorWithCode:OIDErrorCodeUserCanceledAuthorizationFlow
+                               underlyingError:error
+                                   description:nil];
+          [strongSelf->_session failExternalUserAgentFlowWithError:safariError];
+        }
+      }];
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+      authenticationVC.presentationContextProvider = self;
+      authenticationVC.prefersEphemeralWebBrowserSession = YES;
+#endif
+      _webAuthenticationVC = authenticationVC;
+      openedUserAgent = [authenticationVC start];
+    }
+  }
+
+  if (!openedUserAgent) {
+    [self cleanUp];
+    NSError *safariError = [OIDErrorUtilities errorWithCode:OIDErrorCodeSafariOpenError
+                                            underlyingError:nil
+                                                description:@"Unable to open user agent."];
+    [session failExternalUserAgentFlowWithError:safariError];
+  }
+  return openedUserAgent;
+}
+
+- (void)dismissExternalUserAgentAnimated:(BOOL)animated completion:(void (^)(void))completion {
+  if (!_externalUserAgentFlowInProgress) {
+    // Ignore this call if there is no authorization flow in progress.
+    if (completion) completion();
+    return;
+  }
+  
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+  ASWebAuthenticationSession *webAuthenticationVC = _webAuthenticationVC;
+#pragma clang diagnostic pop
+  
+  [self cleanUp];
+  
+  if (webAuthenticationVC) {
+    // dismiss the ASWebAuthenticationSession
+    [webAuthenticationVC cancel];
+    if (completion) completion();
+  } else {
+    if (completion) completion();
+  }
+}
+
+- (void)cleanUp {
+  // The weak references to |_safariVC| and |_session| are set to nil to avoid accidentally using
+  // them while not in an authorization flow.
+  _session = nil;
+  _externalUserAgentFlowInProgress = NO;
+}
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+#pragma mark - ASWebAuthenticationPresentationContextProviding
+
+- (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session API_AVAILABLE(ios(13.0)){
+  return _presentingViewController.view.window;
+}
+#endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Okta/Framework/Info.plist
+++ b/Okta/Framework/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Okta/OktaOidc/Internal/OktaUserAgent.m
+++ b/Okta/OktaOidc/Internal/OktaUserAgent.m
@@ -22,7 +22,7 @@ static NSString *userAgentValue = nil;
 }
 
 +(NSString*)userAgentVersion {
-    return @"3.7.0";
+    return @"3.8.0";
 }
 
 +(NSString*)userAgentHeaderKey {

--- a/Okta/OktaOidc/Internal/Tasks/iOS/OktaOidcBrowserTaskIOS.swift
+++ b/Okta/OktaOidc/Internal/Tasks/iOS/OktaOidcBrowserTaskIOS.swift
@@ -20,6 +20,11 @@ class OktaOidcBrowserTaskIOS: OktaOidcBrowserTask {
     }
 
     override func externalUserAgent() -> OIDExternalUserAgent {
-        return OIDExternalUserAgentIOS(presenting: presenter)
+        if #available(iOS 13.0, *) {
+            return config.noSSO ? OIDExternalUserAgentNoSsoIOS(presenting: presenter) :
+                                  OIDExternalUserAgentIOS(presenting: presenter)
+        } else {
+            return OIDExternalUserAgentIOS(presenting: presenter)
+        }
     }
 }

--- a/Okta/OktaOidc/OktaOidc.h
+++ b/Okta/OktaOidc/OktaOidc.h
@@ -47,6 +47,7 @@
 #import "OIDAuthState+IOS.h"
 #import "OIDAuthorizationService+IOS.h"
 #import "OIDExternalUserAgentIOS.h"
+#import "OIDExternalUserAgentNoSsoIOS.h"
 #import "OIDExternalUserAgentIOSCustomBrowser.h"
 #elif TARGET_OS_MAC
 #import "OIDAuthState+Mac.h"

--- a/Okta/OktaOidc/OktaOidcConfig.swift
+++ b/Okta/OktaOidc/OktaOidcConfig.swift
@@ -20,6 +20,9 @@ public class OktaOidcConfig: NSObject, Codable {
     @objc public let scopes: String
     @objc public let redirectUri: URL
     @objc public let logoutRedirectUri: URL?
+
+    @available(iOS 13.0, *)
+    @objc public lazy var noSSO: Bool = false
     
     @objc public let additionalParams: [String:String]?
 
@@ -73,6 +76,12 @@ public class OktaOidcConfig: NSObject, Codable {
         guard let config = object as? OktaOidcConfig else {
             return false
         }
+        if #available(iOS 13.0, *) {
+            if self.noSSO != config.noSSO {
+                return false
+            }
+        }
+
         return self.clientId == config.clientId &&
                self.issuer == config.issuer &&
                self.scopes == config.scopes &&

--- a/Okta/OktaOidc/OktaOidcKeychain.swift
+++ b/Okta/OktaOidc/OktaOidcKeychain.swift
@@ -82,7 +82,7 @@ public class OktaOidcKeychain: NSObject {
     public class func get(key: String) throws -> Data {
         let q = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecReturnData as String: kCFBooleanTrue,
+            kSecReturnData as String: kCFBooleanTrue as Any,
             kSecMatchLimit as String: kSecMatchLimitOne,
             kSecAttrAccount as String: key
         ] as CFDictionary

--- a/Okta/OktaOidc/iOS/OktaOidc+Browser.swift
+++ b/Okta/OktaOidc/iOS/OktaOidc+Browser.swift
@@ -66,13 +66,4 @@ extension OktaOidc: OktaOidcBrowserProtocolIOS {
         }
         userAgentSession.cancel(completion: completion)
     }
-
-    @available(iOS, obsoleted: 11.0, message: "Unused on iOS 11+")
-    @objc public func resume(_ url: URL, options: [UIApplication.OpenURLOptionsKey : Any]) -> Bool {
-        guard let currentUserSessionTask = currentUserSessionTask else {
-            return false
-        }
-        
-        return currentUserSessionTask.resume(with: url)
-    }
 }

--- a/OktaOidc.podspec
+++ b/OktaOidc.podspec
@@ -1,21 +1,21 @@
 Pod::Spec.new do |s|
   s.name             = 'OktaOidc'
-  s.version          = '3.7.0'
+  s.version          = '3.8.0'
   s.summary          = 'SDK to easily integrate AppAuth with Okta'
   s.description      = <<-DESC
 Integrate your native app with Okta using the AppAuth library.
                        DESC
-  s.platforms    = { :ios => "9.0", :osx => "10.10"}
+  s.platforms    = { :ios => "11.0", :osx => "10.10"}
   s.homepage         = 'https://github.com/okta/okta-oidc-ios'
   s.license          = { :type => 'APACHE2', :file => 'LICENSE' }
   s.authors          = { "Okta Developers" => "developer@okta.com"}
   s.source           = { :git => 'https://github.com/okta/okta-oidc-ios.git', :tag => s.version.to_s }
-  s.swift_version = '4.2'
+  s.swift_version = '5.0'
 
   s.subspec 'AppAuth' do |appauth|
      appauth.source_files = 'Okta/AppAuth/*.{h,m}','Okta/OktaOidc/Internal/OktaUserAgent.{h,m}'
      appauth.ios.source_files      = 'Okta/AppAuth/iOS/*.{h,m}'
-     appauth.ios.deployment_target = '9.0'
+     appauth.ios.deployment_target = '11.0'
      appauth.osx.source_files = 'Okta/AppAuth/macOS/**/*.{h,m}'
      appauth.osx.deployment_target = '10.10'
   end
@@ -32,7 +32,7 @@ Integrate your native app with Okta using the AppAuth library.
         classes.ios.source_files = 'Okta/OktaOidc/iOS/*.{swift}',
                                                   'Okta/OktaOidc/Internal/iOS/*.{swift}',
                                                   'Okta/OktaOidc/Internal/Tasks/iOS/*.{swift}'
-        classes.ios.deployment_target = '9.0'
+        classes.ios.deployment_target = '11.0'
         classes.osx.source_files = 'Okta/OktaOidc/macOS/*.{swift}',
                                                    'Okta/OktaOidc/Internal/macOS/*.{swift}',
                                                    'Okta/OktaOidc/Internal/Tasks/macOS/*.{swift}'

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ You'll also need:
 ## Supported Platforms
 
 ### iOS
-Okta OIDC supports iOS 9 and above.
+Okta OIDC supports iOS 11 and above.
 
 ### macOS
-Okta OIDC supports macOS (OS X) 10.9 and above. Library supports both custom schemes; a loopback HTTP redirects via a small embedded server.
+Okta OIDC supports macOS (OS X) 10.10 and above. Library supports both custom schemes; a loopback HTTP redirects via a small embedded server.
 
 ## Install
 
@@ -184,6 +184,18 @@ let configuration = OktaOidcConfig(with: [
   "login_hint": "username@email.com"
 ])
 ```
+
+### Disable Single Sign-On for the authentication session
+
+You can disable SSO capabilities by setting `noSSO` flag to `true` for `OktaOidcConfig` instance.
+
+```swift
+let configuration = OktaOidcConfig(with: {YourOidcConfiguration})
+if #available(iOS 13.0, *) {
+    configuration?.noSSO = true
+}
+```
+***Note*** Flag is available on iOS 13 and above versions
 
 ## API Reference
 

--- a/Tests/OIDExternalUserAgentNoSsoTests.swift
+++ b/Tests/OIDExternalUserAgentNoSsoTests.swift
@@ -1,0 +1,80 @@
+/*
+* Copyright (c) 2020, Okta, Inc. and/or its affiliates. All rights reserved.
+* The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+*
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+import XCTest
+@testable import OktaOidc
+
+class OIDExternalUserAgentRequestMock: OIDExternalUserAgentRequest {
+    func externalUserAgentRequestURL() -> URL! {
+        return URL(string: "https://tenant.okta.com")!
+    }
+    
+    func redirectScheme() -> String! {
+        return "com.okta.callback://oauth/callback"
+    }
+}
+
+class OIDExternalUserAgentSessionNoSsoMock: NSObject, OIDExternalUserAgentSession {
+
+    var cancelCalled = false
+    var resumeExternalUserAgentFlowCalled = false
+    var failExternalUserAgentFlowWithErrorCalled = false
+    var error: Error?
+    
+    override init() {
+    }
+    
+    func cancel() {
+        cancelCalled = true
+    }
+    
+    func cancel(completion: (() -> Void)? = nil) {
+        cancelCalled = true
+    }
+    
+    func resumeExternalUserAgentFlow(with URL: URL) -> Bool {
+        resumeExternalUserAgentFlowCalled = true
+        return true
+    }
+    
+    func failExternalUserAgentFlowWithError(_ error: Error) {
+        failExternalUserAgentFlowWithErrorCalled = true
+        self.error = error
+    }
+}
+
+class OIDExternalUserAgentNoSsoIOSPartialMock: OIDExternalUserAgentNoSsoIOS {
+@available(iOS 13.0, *)
+    override func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return UIWindow()
+    }
+}
+
+class OIDExternalUserAgentNoSsoTests: XCTestCase {
+
+    func testCreateNoSsoExternalUserAgent_Success() {
+        if #available(iOS 13.0, *) {
+            let mut = OIDExternalUserAgentNoSsoIOSPartialMock(presenting: UIViewController())
+            XCTAssertTrue(mut.present(OIDExternalUserAgentRequestMock(), session: OIDExternalUserAgentSessionNoSsoMock()))
+        }
+    }
+
+    func testCreateNoSsoExternalUserAgent_Failure() {
+        if #available(iOS 13.0, *) {
+            let mut = OIDExternalUserAgentNoSsoIOS(presenting: UIViewController())
+            let sessionMock = OIDExternalUserAgentSessionNoSsoMock()
+            XCTAssertFalse(mut.present(OIDExternalUserAgentRequestMock(), session: sessionMock))
+            XCTAssertTrue(sessionMock.failExternalUserAgentFlowWithErrorCalled)
+            XCTAssertNotNil(sessionMock.error)
+        }
+    }
+}

--- a/Tests/OktaOidcConfigTests.swift
+++ b/Tests/OktaOidcConfigTests.swift
@@ -170,4 +170,25 @@ class OktaOidcConfigTests: XCTestCase {
         OktaOidcConfig.setUserAgent(value: "some user agent")
         XCTAssertEqual(OktaUserAgent.userAgentHeaderValue(), "some user agent")
     }
+
+    func testNoSSOOption() {
+        do {
+            if #available(iOS 13.0, *) {
+                let config = try OktaOidcConfig.default()
+                var oidc = OktaOidcBrowserTaskIOS(presenter: UIViewController(), config: config, oktaAPI: OktaOidcRestApi())
+                var externalUA = oidc.externalUserAgent()
+                XCTAssertTrue(externalUA is OIDExternalUserAgentIOS)
+
+                config.noSSO = true
+                oidc = OktaOidcBrowserTaskIOS(presenter: UIViewController(), config: config, oktaAPI: OktaOidcRestApi())
+                externalUA = oidc.externalUserAgent()
+                XCTAssertTrue(externalUA is OIDExternalUserAgentNoSsoIOS)
+            }
+        } catch let error {
+            XCTAssertEqual(
+                OktaOidcError.missingConfigurationValues.localizedDescription,
+                error.localizedDescription
+            )
+        }
+    }
 }

--- a/UITests/UITestUtils.swift
+++ b/UITests/UITestUtils.swift
@@ -29,18 +29,45 @@ public struct UITestUtils {
         // Sign In via username and password inside of the Safari WebView
         let webViewsQuery = testApp.webViews
         let uiElementUsername = webViewsQuery.textFields.element(boundBy: 0)
-        XCTAssertTrue(uiElementUsername.waitForExistence(timeout: 60))
+        XCTAssertTrue(uiElementUsername.waitForExistence(timeout: 20))
         uiElementUsername.tap()
         uiElementUsername.typeText(username)
-        let uiElementPassword: XCUIElement = webViewsQuery.secureTextFields.element(boundBy: 0)
         if webViewsQuery.buttons["Next"].exists {
             webViewsQuery.buttons["Next"].tap()
-            XCTAssertTrue(uiElementPassword.waitForExistence(timeout: 60))
         }
-        uiElementPassword.tap()
-        sleep(1)
-        uiElementPassword.typeText(password)
-        webViewsQuery.buttons["Sign In"].tap()
+        enterPassword(password, in: webViewsQuery)
+        if webViewsQuery.buttons["Sign In"].exists {
+            webViewsQuery.buttons["Sign In"].tap()
+        } else if webViewsQuery.buttons["Verify"].exists {
+            webViewsQuery.buttons["Verify"].tap()
+        }
+
+        XCTAssertTrue(webViewsQuery.buttons["Verify"].waitForExistence(timeout: 20))
+        enterPassword("okta", in: webViewsQuery)
+        webViewsQuery.buttons["Verify"].tap()
+    }
+
+    func enterPassword(_ password: String, in element: XCUIElementQuery) {
+        var passwordTextField: XCUIElement?
+        if element.secureTextFields.count > 1 {
+            var currentTextFieldWidth: CGFloat = 0.0
+            for i in 0...(element.secureTextFields.count-1) {
+                let textField = element.secureTextFields.element(boundBy: i)
+                if textField.frame.width > currentTextFieldWidth {
+                    passwordTextField = textField
+                    currentTextFieldWidth = textField.frame.width
+                }
+            }
+        } else {
+            passwordTextField = element.secureTextFields.element(boundBy: 0)
+        }
+
+        if let passwordTextField = passwordTextField {
+            XCTAssertTrue(passwordTextField.waitForExistence(timeout: 60))
+            passwordTextField.tap()
+            sleep(1)
+            passwordTextField.typeText(password)
+        }
     }
 
     func getTextViewValue(label: String) -> String? {

--- a/okta-oidc.xcodeproj/project.pbxproj
+++ b/okta-oidc.xcodeproj/project.pbxproj
@@ -36,6 +36,9 @@
 		2F32CCA8229D6B59003A6768 /* OktaOidc.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2F32CA1E229D38D4003A6768 /* OktaOidc.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A10798962322DB8700327ED9 /* OktaSignOutOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10798952322DB8700327ED9 /* OktaSignOutOptions.swift */; };
 		A10798972322DB8700327ED9 /* OktaSignOutOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10798952322DB8700327ED9 /* OktaSignOutOptions.swift */; };
+		A10FA55224B4DA3200E00620 /* OIDExternalUserAgentNoSsoIOS.m in Sources */ = {isa = PBXBuildFile; fileRef = A10FA55124B4DA3200E00620 /* OIDExternalUserAgentNoSsoIOS.m */; };
+		A10FA55424B4DAA600E00620 /* OIDExternalUserAgentNoSsoIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = A10FA55324B4DAA600E00620 /* OIDExternalUserAgentNoSsoIOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A10FA55624B6310500E00620 /* OIDExternalUserAgentNoSsoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10FA55524B6310400E00620 /* OIDExternalUserAgentNoSsoTests.swift */; };
 		A16788992432A5C000D1651D /* OktaRedirectServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16788982432A5BF00D1651D /* OktaRedirectServerTests.swift */; };
 		A167889C2432CDD800D1651D /* OIDRedirectHTTPHandlerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A167889B2432CDD700D1651D /* OIDRedirectHTTPHandlerMock.swift */; };
 		A167889E2433C7B500D1651D /* OktaRedirectServerConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A167889D2433C7B500D1651D /* OktaRedirectServerConfigurationTests.swift */; };
@@ -336,6 +339,9 @@
 		2F32CC8B229D4FCD003A6768 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2F32CC8C229D4FCD003A6768 /* UITestUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITestUtils.swift; sourceTree = "<group>"; };
 		A10798952322DB8700327ED9 /* OktaSignOutOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaSignOutOptions.swift; sourceTree = "<group>"; };
+		A10FA55124B4DA3200E00620 /* OIDExternalUserAgentNoSsoIOS.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OIDExternalUserAgentNoSsoIOS.m; path = AppAuth/iOS/OIDExternalUserAgentNoSsoIOS.m; sourceTree = "<group>"; };
+		A10FA55324B4DAA600E00620 /* OIDExternalUserAgentNoSsoIOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OIDExternalUserAgentNoSsoIOS.h; path = AppAuth/iOS/OIDExternalUserAgentNoSsoIOS.h; sourceTree = "<group>"; };
+		A10FA55524B6310400E00620 /* OIDExternalUserAgentNoSsoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OIDExternalUserAgentNoSsoTests.swift; sourceTree = "<group>"; };
 		A16788982432A5BF00D1651D /* OktaRedirectServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OktaRedirectServerTests.swift; path = Tests/MacOS/OktaRedirectServerTests.swift; sourceTree = SOURCE_ROOT; };
 		A167889B2432CDD700D1651D /* OIDRedirectHTTPHandlerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OIDRedirectHTTPHandlerMock.swift; sourceTree = "<group>"; };
 		A167889D2433C7B500D1651D /* OktaRedirectServerConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaRedirectServerConfigurationTests.swift; sourceTree = "<group>"; };
@@ -725,6 +731,7 @@
 				2F32CC0F229D4CF8003A6768 /* TestUtils.swift */,
 				A16788B524367F5500D1651D /* OktaOidcBrowserTaskIOSTests.swift */,
 				A16788BB2436AE5900D1651D /* OktaOidcBrowserTests.swift */,
+				A10FA55524B6310400E00620 /* OIDExternalUserAgentNoSsoTests.swift */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
@@ -820,6 +827,8 @@
 				A17E38B8234CFF1E00837873 /* OIDExternalUserAgentIOS.m */,
 				A17E38B4234CFF1E00837873 /* OIDExternalUserAgentIOSCustomBrowser.h */,
 				A17E38B6234CFF1E00837873 /* OIDExternalUserAgentIOSCustomBrowser.m */,
+				A10FA55324B4DAA600E00620 /* OIDExternalUserAgentNoSsoIOS.h */,
+				A10FA55124B4DA3200E00620 /* OIDExternalUserAgentNoSsoIOS.m */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
@@ -977,6 +986,7 @@
 				A1763A3B2450BF2B0031E050 /* OktaOidc.h in Headers */,
 				A17E3896234CFEED00837873 /* OIDExternalUserAgentRequest.h in Headers */,
 				A17E39D02357DB0F00837873 /* OktaUserAgent.h in Headers */,
+				A10FA55424B4DAA600E00620 /* OIDExternalUserAgentNoSsoIOS.h in Headers */,
 				A17E38BD234CFF1E00837873 /* OIDAuthorizationService+IOS.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1151,21 +1161,25 @@
 				TargetAttributes = {
 					2F32CA1D229D38D4003A6768 = {
 						CreatedOnToolsVersion = 10.2.1;
+						LastSwiftMigration = 1130;
 					};
 					2F32CB9C229D422F003A6768 = {
 						CreatedOnToolsVersion = 10.2.1;
+						LastSwiftMigration = 1130;
 					};
 					2F32CBD9229D4CE9003A6768 = {
 						CreatedOnToolsVersion = 10.2.1;
+						LastSwiftMigration = 1130;
 						TestTargetID = 2F32CB9C229D422F003A6768;
 					};
 					2F32CC7E229D4FC0003A6768 = {
 						CreatedOnToolsVersion = 10.2.1;
-						LastSwiftMigration = 1100;
+						LastSwiftMigration = 1130;
 						TestTargetID = 2F32CB9C229D422F003A6768;
 					};
 					A17E38DB234D2DF700837873 = {
 						CreatedOnToolsVersion = 11.0;
+						LastSwiftMigration = 1130;
 					};
 					A17E38E3234D2DF800837873 = {
 						CreatedOnToolsVersion = 11.0;
@@ -1280,6 +1294,7 @@
 				A17E3892234CFEED00837873 /* OIDFieldMapping.m in Sources */,
 				A17E389B234CFEED00837873 /* OIDAuthorizationRequest.m in Sources */,
 				A17E38A8234CFEED00837873 /* OIDEndSessionRequest.m in Sources */,
+				A10FA55224B4DA3200E00620 /* OIDExternalUserAgentNoSsoIOS.m in Sources */,
 				A17E38C1234CFF1E00837873 /* OIDAuthState+IOS.m in Sources */,
 				A17E387B234CFEED00837873 /* OIDAuthState.m in Sources */,
 				A17E399B234E65B800837873 /* OktaOidc+Browser.swift in Sources */,
@@ -1348,6 +1363,7 @@
 				2F32CC43229D4D11003A6768 /* OktaOidcConfigTests.swift in Sources */,
 				A17E3A142358FA3300837873 /* OIDURLQueryComponentTests.m in Sources */,
 				2F32CC3B229D4D11003A6768 /* OktaOidcEndpointTests.swift in Sources */,
+				A10FA55624B6310500E00620 /* OIDExternalUserAgentNoSsoTests.swift in Sources */,
 				A16788C12436B1DF00D1651D /* OIDExternalUserAgentSessionMock.swift in Sources */,
 				2F32CC3E229D4D11003A6768 /* OktaOidcStateManagerTests.swift in Sources */,
 			);
@@ -1628,18 +1644,19 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Okta/Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 3.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.okta.okta-oidc";
 				PRODUCT_NAME = OktaOidc;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(SWIFT_MODULE_NAME)-Swift.h";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1656,18 +1673,19 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Okta/Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 3.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.okta.okta-oidc";
 				PRODUCT_NAME = OktaOidc;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(SWIFT_MODULE_NAME)-Swift.h";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1679,14 +1697,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Example/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.okta.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1698,14 +1716,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Example/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.okta.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1715,7 +1733,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1723,7 +1741,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.okta.OktaOidcTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
@@ -1734,7 +1752,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1742,7 +1760,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.okta.OktaOidcTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
@@ -1754,7 +1772,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = UITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1764,7 +1782,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = Example;
 			};
@@ -1776,7 +1794,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = UITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1785,7 +1803,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.okta.OktaOidcUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = Example;
 			};
@@ -1808,11 +1826,12 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MARKETING_VERSION = 3.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.okta.okta-oidc";
 				PRODUCT_NAME = OktaOidc;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1833,11 +1852,12 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MARKETING_VERSION = 3.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.okta.okta-oidc";
 				PRODUCT_NAME = OktaOidc;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/okta-oidc.xcodeproj/xcshareddata/xcschemes/okta-oidc.xcscheme
+++ b/okta-oidc.xcodeproj/xcshareddata/xcschemes/okta-oidc.xcscheme
@@ -66,6 +66,11 @@
                BlueprintName = "OktaOidcUITests"
                ReferencedContainer = "container:okta-oidc.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "OktaUITests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>


### PR DESCRIPTION
### Problem Analysis (Technical)
Need a way to implicitly enable `prefersEphemeralWebBrowserSession`  for `ASWebAuthenticationSession` class.

### Solution (Technical)
- Add `noSSO` flag into `OktaOidcConfig` class
- Create `OIDExternalUserAgentNoSsoIOS` class that conforms to `OIDExternalUserAgent`
- Create instance of `OIDExternalUserAgentNoSsoIOS` if `noSSO` flag is true

### Affected Components
OktaOidcConfig, OktaOidcBrowserTaskIOS

### Tests
Added