### PR TITLE
Fix for Xcode 12 beta compiler bug

### DIFF
--- a/Okta/OktaOidc/OktaOidcStateManager.swift
+++ b/Okta/OktaOidc/OktaOidcStateManager.swift
@@ -98,8 +98,11 @@ open class OktaOidcStateManager: NSObject, NSSecureCoding {
         guard payload.count > 1 else {
             return [:]
         }
-        
-        var encodedPayload = "\(payload[1])"
+
+        /// Required to get around compiler bug in Xcode 12 beta 1 & 2
+        let compilerFix = payload[1]
+
+        var encodedPayload = String(payload[1])
         if encodedPayload.count % 4 != 0 {
             let padding = 4 - encodedPayload.count % 4
             encodedPayload += String(repeating: "=", count: padding)


### PR DESCRIPTION
### Problem Analysis (Technical)
Archiving the framework under Xcode 12 Beta fails when linking `OktaOidc` for `armv7` architecture only:

```
Undefined symbols for architecture armv7:
  "type metadata for Swift._StringObject.Variant", referenced from:
      outlined init with take of Swift._StringObject.Variant in OktaOidcStateManager.o
ld: symbol(s) not found for architecture armv7
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Impact: breaks `carthage build`

### Solution (Technical)
It's a compiler bug, so the fix makes no sense:
- add a line of code to define a `let` which is not used.
- Use `String(aStringSubSequence)` over `"\(aStringSubSequence)"`. Same functionality, different result 🤷 .

Given that this is a compiler bug in an Xcode beta, I imagine you probably don't want to merge this. Might be helpful to leave it up for anyone also suffering the same issue.
