### PR TITLE
Add Support for Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "OktaOidc",
+    platforms: [
+        .macOS(.v10_10), .iOS(.v11)
+    ],
+    products: [
+        .library(name: "OktaOidc", targets: ["OktaOidc"])
+    ],
+    targets: [
+        .target(name: "OktaOidc", dependencies: []),
+        .testTarget(name: "OktaTests", dependencies: ["OktaOidc"])
+    ]
+)


### PR DESCRIPTION
### Problem Analysis (Technical)
The library did not support Swift Package Manager (SPM).

### Solution (Technical)
Added a file, `Package.swift`, that allows integration with SPM.
