### PR TITLE
Pass delegate in get auth state method

### DIFF
--- a/Okta/OktaOidc/Internal/OIDAuthState+Okta.swift
+++ b/Okta/OktaOidc/Internal/OIDAuthState+Okta.swift
@@ -20,7 +20,7 @@ extension OIDAuthState {
         }
 
         // Make authCode request
-        OIDAuthorizationService.perform(authRequest: authRequest, callback: { authResponse, error in
+        OIDAuthorizationService.perform(authRequest: authRequest, delegate: delegate, callback: { authResponse, error in
             guard let authResponse = authResponse else {
                 finalize(nil, OktaOidcError.APIError("Authorization Error: \(error!.localizedDescription)"))
                 return

--- a/Tests/OIDAuthStateTests.swift
+++ b/Tests/OIDAuthStateTests.swift
@@ -1,0 +1,44 @@
+/*
+* Copyright (c) 2020, Okta, Inc. and/or its affiliates. All rights reserved.
+* The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+*
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*
+* See the License for the specific language governing permissions and limitations under the License.
+*/
+
+import XCTest
+@testable import OktaOidc
+
+class OIDAuthStateTests: XCTestCase {
+    var requestMock: OIDAuthorizationRequest!
+    
+    override func setUp() {
+        super.setUp()
+        
+        let testUrl = URL(string: TestUtils.mockIssuer)!
+        let testConfig = OIDServiceConfiguration(authorizationEndpoint: testUrl, tokenEndpoint: testUrl, issuer: testUrl)
+        requestMock = OIDAuthorizationRequest(
+            configuration: testConfig,
+            clientId: TestUtils.mockClientId,
+            clientSecret: nil,
+            scopes: ["openid", "email"],
+            redirectURL: testUrl,
+            responseType: OIDResponseTypeCode,
+            additionalParameters: nil
+        )
+    }
+    
+    func testFireRequest_DelegateNotNil() {
+        let delegateMock = OktaNetworkRequestCustomizationDelegateMock()
+        let authStateExpectation = expectation(description: "Get auth state completed!")
+        OIDAuthState.getState(withAuthRequest: requestMock, delegate: delegateMock) { (state, error) in
+            authStateExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 5.0, handler: nil)
+        XCTAssertTrue(delegateMock.didReceiveCalled)
+    }
+}

--- a/Tests/OktaOIDAuthStateTests.swift
+++ b/Tests/OktaOIDAuthStateTests.swift
@@ -13,7 +13,7 @@
 import XCTest
 @testable import OktaOidc
 
-class OIDAuthStateTests: XCTestCase {
+class OktaOIDAuthStateTests: XCTestCase {
     var requestMock: OIDAuthorizationRequest!
     
     override func setUp() {

--- a/okta-oidc.xcodeproj/project.pbxproj
+++ b/okta-oidc.xcodeproj/project.pbxproj
@@ -257,6 +257,7 @@
 		DEBFB8E82507C53600A27026 /* URLSessionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBFB8E72507C53600A27026 /* URLSessionMock.swift */; };
 		DEE37AD125065C7300318DC3 /* OktaNetworkRequestCustomizationDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E2E1F3472501868D0001DDD5 /* OktaNetworkRequestCustomizationDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E2E1F3482501868E0001DDD5 /* OktaNetworkRequestCustomizationDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E2E1F3472501868D0001DDD5 /* OktaNetworkRequestCustomizationDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E2F6026625104F3000492BEC /* OIDAuthStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F6026525104F3000492BEC /* OIDAuthStateTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -500,6 +501,7 @@
 		DEBFB8E52507C52400A27026 /* OktaNetworkRequestCustomizationDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaNetworkRequestCustomizationDelegateMock.swift; sourceTree = "<group>"; };
 		DEBFB8E72507C53600A27026 /* URLSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionMock.swift; sourceTree = "<group>"; };
 		E2E1F3472501868D0001DDD5 /* OktaNetworkRequestCustomizationDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OktaNetworkRequestCustomizationDelegate.h; path = AppAuth/OktaNetworkRequestCustomizationDelegate.h; sourceTree = "<group>"; };
+		E2F6026525104F3000492BEC /* OIDAuthStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OIDAuthStateTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -748,6 +750,7 @@
 				DEBFB8DF250797F600A27026 /* OktaOidcRestApiTests.swift */,
 				DEBFB8E22507A7A000A27026 /* OIDAuthorizationServiceRequestDelegateTests.swift */,
 				DE10BAB1250A5CAF00655FF8 /* OIDAuthorizationServiceOktaTests.swift */,
+				E2F6026525104F3000492BEC /* OIDAuthStateTests.swift */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
@@ -1384,6 +1387,7 @@
 				A17E3A192358FA3300837873 /* OIDServiceDiscoveryTests.m in Sources */,
 				A17E3A132358FA3300837873 /* OIDRegistrationRequestTests.m in Sources */,
 				A17E3A1F2358FA3300837873 /* OIDRegistrationResponseTests.m in Sources */,
+				E2F6026625104F3000492BEC /* OIDAuthStateTests.swift in Sources */,
 				A17E3A1D2358FA3300837873 /* OIDScopesTests.m in Sources */,
 				DEBFB8E62507C52400A27026 /* OktaNetworkRequestCustomizationDelegateMock.swift in Sources */,
 				2F32CC43229D4D11003A6768 /* OktaOidcConfigTests.swift in Sources */,

--- a/okta-oidc.xcodeproj/project.pbxproj
+++ b/okta-oidc.xcodeproj/project.pbxproj
@@ -257,7 +257,7 @@
 		DEBFB8E82507C53600A27026 /* URLSessionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBFB8E72507C53600A27026 /* URLSessionMock.swift */; };
 		DEE37AD125065C7300318DC3 /* OktaNetworkRequestCustomizationDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E2E1F3472501868D0001DDD5 /* OktaNetworkRequestCustomizationDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E2E1F3482501868E0001DDD5 /* OktaNetworkRequestCustomizationDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E2E1F3472501868D0001DDD5 /* OktaNetworkRequestCustomizationDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E2F6026625104F3000492BEC /* OIDAuthStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F6026525104F3000492BEC /* OIDAuthStateTests.swift */; };
+		E2F6026625104F3000492BEC /* OktaOIDAuthStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F6026525104F3000492BEC /* OktaOIDAuthStateTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -501,7 +501,7 @@
 		DEBFB8E52507C52400A27026 /* OktaNetworkRequestCustomizationDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaNetworkRequestCustomizationDelegateMock.swift; sourceTree = "<group>"; };
 		DEBFB8E72507C53600A27026 /* URLSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionMock.swift; sourceTree = "<group>"; };
 		E2E1F3472501868D0001DDD5 /* OktaNetworkRequestCustomizationDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OktaNetworkRequestCustomizationDelegate.h; path = AppAuth/OktaNetworkRequestCustomizationDelegate.h; sourceTree = "<group>"; };
-		E2F6026525104F3000492BEC /* OIDAuthStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OIDAuthStateTests.swift; sourceTree = "<group>"; };
+		E2F6026525104F3000492BEC /* OktaOIDAuthStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaOIDAuthStateTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -750,7 +750,7 @@
 				DEBFB8DF250797F600A27026 /* OktaOidcRestApiTests.swift */,
 				DEBFB8E22507A7A000A27026 /* OIDAuthorizationServiceRequestDelegateTests.swift */,
 				DE10BAB1250A5CAF00655FF8 /* OIDAuthorizationServiceOktaTests.swift */,
-				E2F6026525104F3000492BEC /* OIDAuthStateTests.swift */,
+				E2F6026525104F3000492BEC /* OktaOIDAuthStateTests.swift */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
@@ -1387,7 +1387,7 @@
 				A17E3A192358FA3300837873 /* OIDServiceDiscoveryTests.m in Sources */,
 				A17E3A132358FA3300837873 /* OIDRegistrationRequestTests.m in Sources */,
 				A17E3A1F2358FA3300837873 /* OIDRegistrationResponseTests.m in Sources */,
-				E2F6026625104F3000492BEC /* OIDAuthStateTests.swift in Sources */,
+				E2F6026625104F3000492BEC /* OktaOIDAuthStateTests.swift in Sources */,
 				A17E3A1D2358FA3300837873 /* OIDScopesTests.m in Sources */,
 				DEBFB8E62507C52400A27026 /* OktaNetworkRequestCustomizationDelegateMock.swift in Sources */,
 				2F32CC43229D4D11003A6768 /* OktaOidcConfigTests.swift in Sources */,


### PR DESCRIPTION
### Problem Analysis (Technical)
In OIDAuthState+Okta.swift, we didn't pass the delegate to the bottom network layer.

### Solution (Technical)
Pass the delegate to the bottom network layer

### Affected Components
OIDAuthState+Okta.swift

### Steps to reproduce:

Actual result:

Expected result:

### Tests
