### PR TITLE
Make sure clean closure of loopback server with incomplete requests.

### DIFF
--- a/Sources/AppAuth/include/OKTRedirectHTTPHandler.h
+++ b/Sources/AppAuth/include/OKTRedirectHTTPHandler.h
@@ -53,6 +53,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithSuccessURL:(nullable NSURL *)successURL;
 
+/*! @brief Sets the success URL for current loopback HTTP redirect URI handler.
+    @param successURL The URL that the user is redirected to after the external user-agent request flow completes
+        either with a result of success or error. The contents of this page should instruct the user
+        to return to the app.
+    @discussion This function will be used if SuccessURL to be changed between different flows.
+ */
+- (void)setSuccessURL:(nullable NSURL *)successURL
+
 /*! @brief Starts listening on the loopback interface on a specified port, and returns a URL
         with the base address. Use the returned redirect URI to build a @c OKTExternalUserAgentRequest,
         and once you initiate the request, set the resulting @c OKTExternalUserAgentSession to

--- a/Sources/AppAuth/macOS/OKTRedirectHTTPHandler.m
+++ b/Sources/AppAuth/macOS/OKTRedirectHTTPHandler.m
@@ -68,6 +68,12 @@ static NSString *const kHTMLErrorRedirectNotValid =
   return self;
 }
 
+- (void)setSuccessURL:(nullable NSURL *)successURL {
+    if (self) {
+      _successURL = [successURL copy];
+    }
+}
+
 - (NSURL *)startHTTPListener:(NSString *)domain withPort:(uint16_t)port error:(NSError **)returnError  {
   // Cancels any pending requests.
   [self cancelHTTPListener];

--- a/Sources/OktaOidc/macOS/Internal/Tasks/OktaOidcBrowserTaskMAC.swift
+++ b/Sources/OktaOidc/macOS/Internal/Tasks/OktaOidcBrowserTaskMAC.swift
@@ -29,8 +29,9 @@ class OktaOidcBrowserTaskMAC: OktaOidcBrowserTask {
          oktaAPI: OktaOidcHttpApiProtocol,
          redirectServerConfiguration: OktaRedirectServerConfiguration? = nil) {
         if let redirectServerConfiguration = redirectServerConfiguration {
-            redirectServer = OktaRedirectServer(successURL: redirectServerConfiguration.successRedirectURL,
-                                                port: redirectServerConfiguration.port ?? 0)
+            redirectServer = OktaRedirectServer.shared
+            redirectServer?.setSuccessURL(successURL: redirectServerConfiguration.successRedirectURL)
+            redirectServer?.setPort(port: redirectServerConfiguration.port ?? 0)
         }
         self.domainName = redirectServerConfiguration?.domainName
         self.redirectServerConfiguration = redirectServerConfiguration

--- a/Sources/OktaOidc/macOS/OktaRedirectServer.swift
+++ b/Sources/OktaOidc/macOS/OktaRedirectServer.swift
@@ -20,11 +20,21 @@ import Foundation
 
 public class OktaRedirectServer {
 
-    var redirectHandler: OKTRedirectHTTPHandler
-    let port: UInt16
+    static let shared = OKTRedirectHTTPHandler(successURL: nil)
 
-    public init(successURL: URL?, port: UInt16 = 0) {
+    let redirectHandler: OKTRedirectHTTPHandler
+    var port: UInt16
+
+    private init(successURL: URL?, port: UInt16 = 0) {
         redirectHandler = OKTRedirectHTTPHandler(successURL: successURL)
+        self.port = port
+    }
+
+    public func setSuccessURL(successURL: URL?) {
+        redirectHandler.setSuccessURL(successURL: successURL)
+    }
+
+    public func setPort(port: UInt16 = 0) {
         self.port = port
     }
 


### PR DESCRIPTION

Resolves: OKTA-350391

### Problem Analysis (Technical)
The flow which triggers one more OIDC flow, cancelling previous session and starting new listener.
The flow fails as CFSocketSetAddress fails with error 48.

### Solution (Technical)
Making OktaRedirectServer as singleton

### Affected Components
MacOS

### Steps to reproduce:

If OIDC flow is not complete for example:

Click on Add Another account to add second user
Provide URL
Get redirect to browser But do not provide credentials there
Then start new OIDC flow

Open OV after above flow
Got to first user and say "Enable Touch ID" --> fails
Actual result:
OIDC flow fails.

Expected result:
User should be redirected to browser.

### Tests
