### PR TITLE
Allow IDP parameters to be supplied when invoking signInWithBrowser

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Start the authorization flow by simply calling `signInWithBrowser`. In case of s
 
 #### iOS
 ```swift
-oktaOidc.signInWithBrowser(from: viewController, payload: ["idp": "your_idp_here"]) { stateManager, error in
+oktaOidc.signInWithBrowser(from: viewController, additionalParameters: ["idp": "your_idp_here"]) { stateManager, error in
   if let error = error {
     // Error
     return
@@ -212,7 +212,7 @@ Sample app [example](https://github.com/okta/samples-ios/blob/master/browser-sig
 // Create redirect server configuration and start local HTTP server if you don't want to use custom schemes
 let serverConfig = OktaRedirectServerConfiguration.default
 serverConfig.port = 63875
-oktaOidc.signInWithBrowser(redirectServerConfiguration: serverConfig, payload: ["idp": "your_idp_here"]) { stateManager, error in
+oktaOidc.signInWithBrowser(redirectServerConfiguration: serverConfig, additionalParameters: ["idp": "your_idp_here"]) { stateManager, error in
   if let error = error {
     // Error
     return

--- a/README.md
+++ b/README.md
@@ -188,11 +188,13 @@ To use this SDK in Objective-C project, you should do the following:
 
 ### signInWithBrowser
 
-Start the authorization flow by simply calling `signIn`. In case of successful authorization, this operation will return valid `OktaOidcStateManager` in its callback. Clients are responsible for further storage and maintenance of the manager.
+Start the authorization flow by simply calling `signInWithBrowser`. In case of successful authorization, this operation will return valid `OktaOidcStateManager` in its callback. Clients are responsible for further storage and maintenance of the manager.
+
+**Note**: IDP can be passed by specifying an argument with the idp parameter.
 
 #### iOS
 ```swift
-oktaOidc.signInWithBrowser(from: viewController) { stateManager, error in
+oktaOidc.signInWithBrowser(from: viewController, payload: ["idp": "your_idp_here"]) { stateManager, error in
   if let error = error {
     // Error
     return
@@ -210,7 +212,7 @@ Sample app [example](https://github.com/okta/samples-ios/blob/master/browser-sig
 // Create redirect server configuration and start local HTTP server if you don't want to use custom schemes
 let serverConfig = OktaRedirectServerConfiguration.default
 serverConfig.port = 63875
-oktaOidc.signInWithBrowser(redirectServerConfiguration: serverConfig) { stateManager, error in
+oktaOidc.signInWithBrowser(redirectServerConfiguration: serverConfig, payload: ["idp": "your_idp_here"]) { stateManager, error in
   if let error = error {
     // Error
     return

--- a/Sources/OktaOidc/Common/OktaOidc.swift
+++ b/Sources/OktaOidc/Common/OktaOidc.swift
@@ -77,7 +77,7 @@ public class OktaOidc: NSObject {
 
     func signOutWithBrowserTask(_ task: OktaOidcBrowserTask,
                                 idToken: String,
-                               callback: @escaping ((Error?) -> Void)) {
+                                callback: @escaping ((Error?) -> Void)) {
         currentUserSessionTask = task
 
         task.signOutWithIdToken(idToken: idToken) { [weak self] _, error in

--- a/Sources/OktaOidc/Common/OktaOidcConfig.swift
+++ b/Sources/OktaOidc/Common/OktaOidcConfig.swift
@@ -54,7 +54,7 @@ public class OktaOidcConfig: NSObject {
         self.scopes = scopes
         self.redirectUri = redirectUri
         
-        if  let logoutRedirectUriString = dict["logoutRedirectUri"] {
+        if let logoutRedirectUriString = dict["logoutRedirectUri"] {
             logoutRedirectUri = URL(string: logoutRedirectUriString)
         } else {
             logoutRedirectUri = nil
@@ -115,6 +115,29 @@ public class OktaOidcConfig: NSObject {
             delegateQueue: .main)
         
         OKTURLSessionProvider.setSession(session)
+    }
+    
+    public func configuration(withAdditionalParams config: [String: String]) throws -> OktaOidcConfig {
+        guard config.count > 0 else { return self }
+
+        var dict: [String:String] = additionalParams?.merging(config, uniquingKeysWith: { (_, new) -> String in
+            return new
+        }) ?? config
+        
+        dict["issuer"] = issuer
+        dict["clientId"] = clientId
+        dict["redirectUri"] = redirectUri.absoluteString
+        dict["scopes"] = scopes
+        if let logoutRedirectUri = logoutRedirectUri {
+            dict["logoutRedirectUri"] = logoutRedirectUri.absoluteString
+        }
+        
+        let result = try OktaOidcConfig(with: dict)
+        result.requestCustomizationDelegate = requestCustomizationDelegate
+        if #available(iOS 13.0, *) {
+            result.noSSO = noSSO
+        }
+        return result
     }
 
     private static func extractAdditionalParams(_ config: [String: String]) -> [String: String]? {

--- a/Sources/OktaOidc/Common/OktaOidcStateManager.swift
+++ b/Sources/OktaOidc/Common/OktaOidcStateManager.swift
@@ -135,11 +135,11 @@ open class OktaOidcStateManager: NSObject, NSSecureCoding {
     }
     
     @objc public func introspect(token: String?, callback: @escaping ([String : Any]?, Error?) -> Void) {
-        perfromRequest(to: .introspection, token: token, callback: callback)
+        performRequest(to: .introspection, token: token, callback: callback)
     }
 
     @objc public func revoke(_ token: String?, callback: @escaping (Bool, Error?) -> Void) {
-        perfromRequest(to: .revocation, token: token) { payload, error in
+        performRequest(to: .revocation, token: token) { payload, error in
             if let error = error {
                 callback(false, error)
                 return
@@ -168,7 +168,7 @@ open class OktaOidcStateManager: NSObject, NSSecureCoding {
 
         let headers = ["Authorization": "Bearer \(token)"]
         
-        perfromRequest(to: .userInfo, headers: headers, callback: callback)
+        performRequest(to: .userInfo, headers: headers, callback: callback)
     }
 }
 
@@ -234,7 +234,7 @@ private extension OktaOidcStateManager {
     }
 
     
-    func perfromRequest(to endpoint: OktaOidcEndpoint,
+    func performRequest(to endpoint: OktaOidcEndpoint,
                         token: String?,
                         callback: @escaping ([String : Any]?, OktaOidcError?) -> Void) {
         guard let token = token else {
@@ -246,10 +246,10 @@ private extension OktaOidcStateManager {
         
         let postString = "token=\(token)&client_id=\(clientId)"
         
-        perfromRequest(to: endpoint, postString: postString, callback: callback)
+        performRequest(to: endpoint, postString: postString, callback: callback)
     }
     
-    func perfromRequest(to endpoint: OktaOidcEndpoint,
+    func performRequest(to endpoint: OktaOidcEndpoint,
                         headers: [String: String]? = nil,
                         postString: String? = nil,
                         callback: @escaping ([String : Any]?, OktaOidcError?) -> Void) {

--- a/Sources/OktaOidc/iOS/OktaOidc+BrowserIOS.swift
+++ b/Sources/OktaOidc/iOS/OktaOidc+BrowserIOS.swift
@@ -19,9 +19,23 @@ extension OktaOidc: OktaOidcBrowserProtocolIOS {
 
     @objc public func signInWithBrowser(from presenter: UIViewController,
                                         callback: @escaping ((OktaOidcStateManager?, Error?) -> Void)) {
+        signInWithBrowser(from: presenter, payload: [:], callback: callback)
+    }
+    
+    @objc public func signInWithBrowser(from presenter: UIViewController,
+                                        payload: [String:String],
+                                        callback: @escaping ((OktaOidcStateManager?, Error?) -> Void)) {
+        let config: OktaOidcConfig
+        do {
+            config = try configuration.configuration(withAdditionalParams: payload)
+        } catch {
+            callback(nil, error)
+            return
+        }
+            
         let oktaAPI = OktaOidcRestApi()
-        oktaAPI.requestCustomizationDelegate = configuration.requestCustomizationDelegate
-        let signInTask = OktaOidcBrowserTaskIOS(presenter: presenter, config: configuration, oktaAPI: oktaAPI)
+        oktaAPI.requestCustomizationDelegate = config.requestCustomizationDelegate
+        let signInTask = OktaOidcBrowserTaskIOS(presenter: presenter, config: config, oktaAPI: oktaAPI)
         signInWithBrowserTask(signInTask, callback: callback)
     }
 

--- a/Sources/OktaOidc/iOS/OktaOidc+BrowserIOS.swift
+++ b/Sources/OktaOidc/iOS/OktaOidc+BrowserIOS.swift
@@ -19,15 +19,15 @@ extension OktaOidc: OktaOidcBrowserProtocolIOS {
 
     @objc public func signInWithBrowser(from presenter: UIViewController,
                                         callback: @escaping ((OktaOidcStateManager?, Error?) -> Void)) {
-        signInWithBrowser(from: presenter, payload: [:], callback: callback)
+        signInWithBrowser(from: presenter, additionalParameters: [:], callback: callback)
     }
     
     @objc public func signInWithBrowser(from presenter: UIViewController,
-                                        payload: [String:String],
+                                        additionalParameters: [String:String],
                                         callback: @escaping ((OktaOidcStateManager?, Error?) -> Void)) {
         let config: OktaOidcConfig
         do {
-            config = try configuration.configuration(withAdditionalParams: payload)
+            config = try configuration.configuration(withAdditionalParams: additionalParameters)
         } catch {
             callback(nil, error)
             return

--- a/Sources/OktaOidc/macOS/OktaOidc+BrowserMAC.swift
+++ b/Sources/OktaOidc/macOS/OktaOidc+BrowserMAC.swift
@@ -19,7 +19,23 @@ extension OktaOidc: OktaOidcBrowserProtocolMAC {
 
     @objc public func signInWithBrowser(redirectServerConfiguration: OktaRedirectServerConfiguration? = nil,
                                         callback: @escaping ((OktaOidcStateManager?, Error?) -> Void)) {
-        let signInTask = OktaOidcBrowserTaskMAC(config: configuration,
+        signInWithBrowser(redirectServerConfiguration: redirectServerConfiguration,
+                          payload: [:],
+                          callback: callback)
+    }
+    
+    @objc public func signInWithBrowser(redirectServerConfiguration: OktaRedirectServerConfiguration? = nil,
+                                        payload: [String:String],
+                                        callback: @escaping ((OktaOidcStateManager?, Error?) -> Void)) {
+        let config: OktaOidcConfig
+        do {
+            config = try configuration.configuration(withAdditionalParams: payload)
+        } catch {
+            callback(nil, error)
+            return
+        }
+            
+        let signInTask = OktaOidcBrowserTaskMAC(config: config,
                                                 oktaAPI: OktaOidcRestApi(),
                                                 redirectServerConfiguration: redirectServerConfiguration)
         signInWithBrowserTask(signInTask) { stateManager, error in

--- a/Sources/OktaOidc/macOS/OktaOidc+BrowserMAC.swift
+++ b/Sources/OktaOidc/macOS/OktaOidc+BrowserMAC.swift
@@ -20,16 +20,16 @@ extension OktaOidc: OktaOidcBrowserProtocolMAC {
     @objc public func signInWithBrowser(redirectServerConfiguration: OktaRedirectServerConfiguration? = nil,
                                         callback: @escaping ((OktaOidcStateManager?, Error?) -> Void)) {
         signInWithBrowser(redirectServerConfiguration: redirectServerConfiguration,
-                          payload: [:],
+                          additionalParameters: [:],
                           callback: callback)
     }
     
     @objc public func signInWithBrowser(redirectServerConfiguration: OktaRedirectServerConfiguration? = nil,
-                                        payload: [String:String],
+                                        additionalParameters: [String:String],
                                         callback: @escaping ((OktaOidcStateManager?, Error?) -> Void)) {
         let config: OktaOidcConfig
         do {
-            config = try configuration.configuration(withAdditionalParams: payload)
+            config = try configuration.configuration(withAdditionalParams: additionalParameters)
         } catch {
             callback(nil, error)
             return

--- a/Tests/OktaOidcTests/OktaOidcBrowserTests.swift
+++ b/Tests/OktaOidcTests/OktaOidcBrowserTests.swift
@@ -20,8 +20,11 @@ import XCTest
 #if os(iOS)
 
 class OktaOidcPartialMock: OktaOidc {
+    var originalBrowserTask: OktaOidcBrowserTask? = nil
+    
     override func signInWithBrowserTask(_ task: OktaOidcBrowserTask,
                                         callback: @escaping ((OktaOidcStateManager?, Error?) -> Void)) {
+        originalBrowserTask = task
         DispatchQueue.main.async {
             let browserTaskIOS = task as! OktaOidcBrowserTaskIOS
             let task = OktaOidcBrowserTaskIOSMock(presenter: browserTaskIOS.presenter,
@@ -32,6 +35,7 @@ class OktaOidcPartialMock: OktaOidc {
     }
 
     override func signOutWithBrowserTask(_ task: OktaOidcBrowserTask, idToken: String, callback: @escaping ((Error?) -> Void)) {
+        originalBrowserTask = task
         DispatchQueue.main.async {
             let browserTaskIOS = task as! OktaOidcBrowserTaskIOS
             let task = OktaOidcBrowserTaskIOSMock(presenter: browserTaskIOS.presenter,
@@ -59,6 +63,25 @@ class OktaOidcBrowserTests: XCTestCase {
             signInExpectation.fulfill()
         }
         waitForExpectations(timeout: 5.0, handler: nil)
+    }
+
+    func testSignInSuccessFlowWithAdditionalParams() {
+        guard let oidc = try? OktaOidcPartialMock(configuration: createTestConfig()) else {
+            XCTFail("Failed to create oidc object")
+            return
+        }
+        
+        let signInExpectation = expectation(description: "Completion should be called!")
+        oidc.signInWithBrowser(from: UIViewController(), payload: ["additional": "param"]) { stateManager, error in
+            XCTAssertNotNil(stateManager)
+            XCTAssertNotNil(stateManager?.accessToken)
+            XCTAssertNotNil(stateManager?.refreshToken)
+            XCTAssertNil(error)
+            signInExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 5.0, handler: nil)
+        
+        XCTAssertEqual(oidc.originalBrowserTask?.config.additionalParams, ["additional": "param"])
     }
 
     func testSignInFailureFlow() {

--- a/Tests/OktaOidcTests/OktaOidcBrowserTests.swift
+++ b/Tests/OktaOidcTests/OktaOidcBrowserTests.swift
@@ -72,7 +72,7 @@ class OktaOidcBrowserTests: XCTestCase {
         }
         
         let signInExpectation = expectation(description: "Completion should be called!")
-        oidc.signInWithBrowser(from: UIViewController(), payload: ["additional": "param"]) { stateManager, error in
+        oidc.signInWithBrowser(from: UIViewController(), additionalParameters: ["additional": "param"]) { stateManager, error in
             XCTAssertNotNil(stateManager)
             XCTAssertNotNil(stateManager?.accessToken)
             XCTAssertNotNil(stateManager?.refreshToken)

--- a/Tests/OktaOidcTests/OktaOidcConfigTests.swift
+++ b/Tests/OktaOidcTests/OktaOidcConfigTests.swift
@@ -112,6 +112,38 @@ class OktaOidcConfigTests: XCTestCase {
         }
     }
     
+    func testCloningConfigWithAdditionalParams() throws {
+        let dict = [
+            "clientId" : "test_client_id",
+            "issuer" : "http://example.com",
+            "scopes" : "test_scope",
+            "redirectUri" : "com.test:/callback",
+            "logoutRedirectUri" : "com.test:/logout"
+        ]
+        
+        let delegate = OktaNetworkRequestCustomizationDelegateMock()
+        
+        let configOrig = try OktaOidcConfig(with: dict)
+        configOrig.requestCustomizationDelegate = delegate
+        XCTAssertNotNil(configOrig)
+        XCTAssertEqual(true, configOrig.additionalParams?.isEmpty)
+
+        let configCopy1 = try configOrig.configuration(withAdditionalParams: ["additional": "param"])
+        XCTAssertNotNil(configCopy1)
+        XCTAssertEqual(configCopy1.additionalParams, ["additional": "param"])
+        XCTAssertEqual(configOrig.clientId, configCopy1.clientId)
+        XCTAssertEqual(configOrig.issuer, configCopy1.issuer)
+        XCTAssertEqual(configOrig.scopes, configCopy1.scopes)
+        XCTAssertEqual(configOrig.redirectUri, configCopy1.redirectUri)
+        XCTAssertEqual(configOrig.logoutRedirectUri, configCopy1.logoutRedirectUri)
+        XCTAssertEqual(configOrig.requestCustomizationDelegate as! OktaNetworkRequestCustomizationDelegateMock,
+                       configCopy1.requestCustomizationDelegate as! OktaNetworkRequestCustomizationDelegateMock)
+        XCTAssertEqual(configOrig.clientId, configCopy1.clientId)
+
+        let configCopy2 = try configCopy1.configuration(withAdditionalParams: ["more": "params"])
+        XCTAssertEqual(configCopy2.additionalParams, ["additional": "param", "more": "params"])
+    }
+    
     #if !SWIFT_PACKAGE
     /// **Note:** Unit tests in Swift Package Manager do not support tests run from a host application, meaning some iOS features are unavailable.
     func testDefaultConfig() {

--- a/Tests/OktaOidcTests/OktaOidcConfigTests.swift
+++ b/Tests/OktaOidcTests/OktaOidcConfigTests.swift
@@ -13,6 +13,10 @@
 import XCTest
 @testable import OktaOidc
 
+#if SWIFT_PACKAGE
+@testable import TestCommon
+#endif
+
 class OktaOidcConfigTests: XCTestCase {
     
     func testCreation() {


### PR DESCRIPTION
### Problem Analysis (Technical)

When signing in, additional parameters may be required without rebuilding the Okta config from scratch.

### Solution (Technical)

Add an additional optional argument to supply a dictionary of values to signInWithBrowser, and merge that into a new configuration that is supplied to the login task.

### Affected Components


### Steps to reproduce:

Actual result:

Expected result:

### Tests
