### PR TITLE
OKTA-362596, OKTA-365884 Unit tests: Cover State Manager by additiona…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,14 +10,36 @@ project.xcworkspace
 Okta.xcworkspace/
 DerivedData
 /.build
-/.swiftpm
 
 # Examples
 Example/Podfile.lock
 Example/Pods
 Example/build/
 
-
-# IDEs
+# Xcode
 *.xccheckout
-.idea/
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+Packages/
+Package.pins
+Package.resolved
+/.swiftpm
+
+# CocoaPods
+Pods/
+
+# Carthage
+Carthage/Checkouts
+Carthage/Build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode11.5
+osx_image: xcode12.2
 jobs:
   include:
     - stage: Unit tests iOS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: objective-c
 osx_image: xcode12.2
+before_install:
+  - gem install cocoapods
+  - brew update
+  - brew outdated carthage || brew upgrade carthage
 jobs:
   include:
     - stage: Unit tests iOS
@@ -25,6 +29,7 @@ jobs:
     - stage: Carthage validation
       name: iOS
       script:
-      # Until XCFramework is not supported.
-      # https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md 
+      # Test two workarounds 
+      # https://github.com/Carthage/Carthage#getting-started
       - ./scripts/carthage-xcode-12.sh build --no-skip-current
+      - carthage build --use-xcframeworks --no-skip-current

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,6 @@ jobs:
     - stage: Carthage validation
       name: iOS
       script:
-      - carthage build --no-skip-current
+      # Until XCFramework is not supported.
+      # https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md 
+      - ./scripts/carthage-xcode-12.sh build --no-skip-current

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![iOS_14 ready](https://img.shields.io/badge/iOS%2014-IN%20PROGRESS-green?style=for-the-badge&logo=apple)
 
 [<img src="https://aws1.discourse-cdn.com/standard14/uploads/oktadev/original/1X/0c6402653dfb70edc661d4976a43a46f33e5e919.png" align="right" width="256px"/>](https://devforum.okta.com/)
-[![CI Status](http://img.shields.io/travis/okta/okta-oidc-ios.svg?style=flat)](https://travis-ci.org/okta/okta-oidc-ios)
+[![CI Status](http://img.shields.io/travis/okta/okta-oidc-ios.svg?style=flat)](https://travis-ci.com/okta/okta-oidc-ios)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Version](https://img.shields.io/cocoapods/v/OktaOidc.svg?style=flat)](http://cocoapods.org/pods/OktaOidc)
 [![License](https://img.shields.io/cocoapods/l/OktaOidc.svg?style=flat)](http://cocoapods.org/pods/OktaOidc)
@@ -510,7 +510,7 @@ You can also consider the following workarounds:
 ### Carthage fails on Xcode 12 
 Carthage throws the error when you install the dependencies with the command `carthage update`. The issue happens only on Xcode 12 and higher versions:
 
-```powershell
+```bash
 Build Failed
 	Task failed with exit code 1:
 	/usr/bin/xcrun lipo -create /Users/user/Library/Caches/org.carthage.CarthageKit/DerivedData/12.4_12D4e/okta-oidc-ios/3.10.1/Build/Intermediates.noindex/ArchiveIntermediates/okta-oidc/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/OktaOidc.framework/OktaOidc /Users/user/Library/Caches/org.carthage.CarthageKit/DerivedData/12.4_12D4e/okta-oidc-ios/3.10.1/Build/Products/Release-iphonesimulator/OktaOidc.framework/OktaOidc -output /Users/user/{ProjectName}/Carthage/Build/iOS/OktaOidc.framework/OktaOidc
@@ -520,16 +520,35 @@ This usually indicates that project itself failed to compile. Please check the x
 
 The reason is that Xcode 12 introduced support of the Apple Silicon and Xcode generates duplicated architectures in frameworks. XCFrameworks are still not supported by Carthage, therefore a workaround should be used.
 
-##### Workaround
+##### Solution #1: XCFrameworks
 
-Launch Carthage via [the script](/scripts/carthage-xcode-12.sh), it will remove duplicated architectures and produce working frameworks.
+You should update Carthage to the version 0.37.0 or higher. 
+
+1. Run in Terminal the following command:
+```bash
+brew upgrade carthage
+```
+2. Make sure the version is correct: 
+```bash
+carthage version
+```
+3. Navigate through Terminal to project folder and run: 
+```bash
+carthage update --use-xcframeworks
+```
+4. Open `General` settings tab in Xcode, in the `Frameworks, Libraries, and Embedded Content` section, drag and drop each XCFramework you want to use from the `Carthage/Build` folder.
+
+> If your existing project is based on discrete framework bundles and you may want to migrate to XCFrameworks, then follow [Carthage migration documentation](https://github.com/Carthage/Carthage#migrating-a-project-from-framework-bundles-to-xcframeworks).
+
+##### Solution #2: Workaround script
+
+Launch Carthage via [the script](/scripts/carthage-xcode-12.sh), it will remove duplicated architectures and produce correct framework bundles.
 
 1. Put the script somewhere to your `PATH` (e.g.: `/usr/local/bin/carthage.sh`).
 2. Make the script executable, so open your Terminal and execute:
 ```sh
 chmod +x /{path_to_script_folder}/carthage.sh
 ```
-
 3. Run the script whenever you want to use Carthage:
 ```sh
 carthage.sh update

--- a/README.md
+++ b/README.md
@@ -522,4 +522,17 @@ The reason is that Xcode 12 introduced support of the Apple Silicon and Xcode ge
 
 ##### Workaround
 
-Launch Carthage via [the script](/scripts/carthage-xcode-12.sh), it will remove duplicated architectures and produce working frameworks. For more details, follow [official Carthage documentation](https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md#workaround).
+Launch Carthage via [the script](/scripts/carthage-xcode-12.sh), it will remove duplicated architectures and produce working frameworks.
+
+1. Put the script somewhere to your `PATH` (e.g.: `/usr/local/bin/carthage.sh`).
+2. Make the script executable, so open your Terminal and execute:
+```sh
+chmod +x /{path_to_script_folder}/carthage.sh
+```
+
+3. Run the script whenewher you want to use Carthage:
+```sh
+carthage.sh update
+```
+
+For more information, follow [official Carthage documentation](https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md#workaround).

--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ Launch Carthage via [the script](/scripts/carthage-xcode-12.sh), it will remove 
 chmod +x /{path_to_script_folder}/carthage.sh
 ```
 
-3. Run the script whenewher you want to use Carthage:
+3. Run the script whenever you want to use Carthage:
 ```sh
 carthage.sh update
 ```

--- a/README.md
+++ b/README.md
@@ -506,3 +506,20 @@ Known iOS issue where iOS doesn't provide any good ways to terminate active auth
 You can also consider the following workarounds:
 - Use `noSSO` option in OIDC configuration object if you don't need SSO capabilites. Also note that this option works only on iOS 13+ versions
 - Fork repository and change user-agent implementation(`OIDExternalUserAgentIOS.m`) to use `SFSafariViewController` only. Some pitfalls of this approach described [here](https://github.com/okta/okta-oidc-ios/issues/181)
+
+### Carthage fails on Xcode 12 
+Carthage throws the error when you install the dependencies with the command `carthage update`. The issue happens only on Xcode 12 and higher versions:
+
+```powershell
+Build Failed
+	Task failed with exit code 1:
+	/usr/bin/xcrun lipo -create /Users/user/Library/Caches/org.carthage.CarthageKit/DerivedData/12.4_12D4e/okta-oidc-ios/3.10.1/Build/Intermediates.noindex/ArchiveIntermediates/okta-oidc/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/OktaOidc.framework/OktaOidc /Users/user/Library/Caches/org.carthage.CarthageKit/DerivedData/12.4_12D4e/okta-oidc-ios/3.10.1/Build/Products/Release-iphonesimulator/OktaOidc.framework/OktaOidc -output /Users/user/{ProjectName}/Carthage/Build/iOS/OktaOidc.framework/OktaOidc
+
+This usually indicates that project itself failed to compile. Please check the xcodebuild log for more details: /var/folders/2x/q10zv0gx4112thm7dd13szmm0000gn/T/carthage-xcodebuild.YaJjLW.log
+```
+
+The reason is that Xcode 12 introduced support of the Apple Silicon and Xcode generates duplicated architectures in frameworks. XCFrameworks are still not supported by Carthage, therefore a workaround should be used.
+
+##### Workaround
+
+Launch Carthage via [the script](/scripts/carthage-xcode-12.sh), it will remove duplicated architectures and produce working frameworks. For more details, follow [official Carthage documentation](https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md#workaround).

--- a/Tests/Common/OKTTokensAuthMock.swift
+++ b/Tests/Common/OKTTokensAuthMock.swift
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+#if SWIFT_PACKAGE
+@testable import OktaOidc_AppAuth
+#else
+@testable import OktaOidc
+#endif
+
+final class OKTTokensAuthMock: OKTAuthState {
+    
+    private var shouldFailRefresh: Bool = false
+    
+    static func makeDefault(expiresIn: TimeInterval = 10, expiredIDToken: Bool = false, shouldFailRefresh: Bool = false) -> OKTAuthState {
+        let issuer = URL(string: TestUtils.mockIssuer)!
+        let mockConfig = TestUtils.makeMockServiceConfig(issuer: issuer)
+        
+        let mockAuthRequest = OKTAuthorizationRequest(
+            configuration: mockConfig,
+            clientId: TestUtils.mockClientId,
+            clientSecret: nil,
+            scopes: ["openid", "email"],
+            redirectURL: issuer,
+            responseType: OKTResponseTypeCode,
+            additionalParameters: nil
+        )
+        
+        let mockAuthResponse = OKTAuthorizationResponse(
+            request: mockAuthRequest,
+            parameters: ["code": "mockAuthCode" as NSCopying & NSObjectProtocol]
+        )
+        
+        let mockTokenRequest = OKTTokenRequest(
+            configuration: mockAuthResponse.request.configuration,
+            grantType: OKTGrantTypeRefreshToken,
+            authorizationCode: mockAuthResponse.authorizationCode,
+            redirectURL: mockAuthResponse.request.redirectURL,
+            clientID: mockAuthResponse.request.clientID,
+            clientSecret: mockAuthResponse.request.clientSecret,
+            scope: mockAuthResponse.scope,
+            refreshToken: nil,
+            codeVerifier: mockAuthResponse.request.codeVerifier,
+            additionalParameters: nil
+        )
+        
+        let mockTokenResponse = OKTTokenResponse(
+            request: mockTokenRequest,
+            parameters: [
+                "expires_in": (expiresIn) as NSCopying & NSObjectProtocol,
+                "access_token": TestUtils.mockAccessToken as NSCopying & NSObjectProtocol,
+                "id_token": idToken(expired: expiredIDToken) as NSCopying & NSObjectProtocol
+            ]
+        )
+        
+        let mockAuthState = OKTTokensAuthMock(authorizationResponse: mockAuthResponse, tokenResponse: mockTokenResponse)
+        mockAuthState.setShouldFailRefresh(shouldFailRefresh)
+        
+        return mockAuthState
+    }
+    
+    func setShouldFailRefresh(_ shouldFail: Bool) {
+        self.shouldFailRefresh = shouldFail
+    }
+    
+    override func performAction(freshTokens action: @escaping OKTAuthStateAction) {
+        if shouldFailRefresh {
+            action(nil, nil, NSError(domain: "Okta Auth refresh", code: 404))
+            return
+        }
+        
+        let mockTokenRequest = OKTTokenRequest(
+            configuration: lastAuthorizationResponse.request.configuration,
+            grantType: OKTGrantTypeRefreshToken,
+            authorizationCode: nil,
+            redirectURL: nil,
+            clientID: lastAuthorizationResponse.request.clientID,
+            clientSecret: lastAuthorizationResponse.request.clientSecret,
+            scope: nil,
+            refreshToken: refreshToken,
+            codeVerifier: nil,
+            additionalParameters: nil
+        )
+        
+        let mockTokenResponse = OKTTokenResponse(request: mockTokenRequest, parameters: ["refresh_token": "New Refresh Token" as NSCopying & NSObjectProtocol])
+        
+        update(with: mockTokenResponse, error: nil)
+        
+        action("Access JWT", mockTokenResponse.refreshToken, nil)
+    }
+    
+    private static func idToken(expired: Bool) -> String {
+        if expired {
+            // Expired in 2019
+            return """
+            eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9\
+            .eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwiaWF0IjoxNDIyNTM1MDA1LCJleHAiOjE1NDg3NjU0MDUsImF1ZCI6IlVuaXQgdGVzdHMiLCJzdWIiOiJleGFtcGxlQGV4YW1wbGUuY29tIn0\
+            .NMvDKlInct4zuu5VMTb30ocuSSf_i8EkQTbwJTQH1RA
+            """
+        }
+        // Expiration in 2040
+        return """
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9\
+        .eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwiaWF0IjoxNDIyNTM1MDA1LCJleHAiOjIyMTE0NTM0MDUsImF1ZCI6IlVuaXQgdGVzdHMiLCJzdWIiOiJleGFtcGxlQGV4YW1wbGUuY29tIn0\
+        .2o_niz5GJdXdgXX3sl4zo1AKEVelHVJ70dqav62qlaI
+        """
+    }
+}

--- a/Tests/Common/TestUtils.swift
+++ b/Tests/Common/TestUtils.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
@@ -33,13 +33,17 @@ struct TestUtils {
     static var authStateManager = { return TestUtils.setupMockAuthStateManager(issuer: mockIssuer, clientId: mockClientId) }
     static var authStateManagerWithExpiration = { return TestUtils.setupMockAuthStateManager(issuer: mockIssuer, clientId: mockClientId, expiresIn: 5) }
     
+    static func makeMockServiceConfig(issuer: URL) -> OKTServiceConfiguration {
+        OKTServiceConfiguration(authorizationEndpoint: issuer, tokenEndpoint: issuer, issuer: issuer)
+    }
+    
     static func setupMockAuthState(issuer: String,
                                    clientId: String,
                                    expiresIn: TimeInterval = 300,
                                    skipTokenResponse: Bool = false) -> OKTAuthState {
         // Creates a mock Okta Auth State Manager object
         let fooURL = URL(string: issuer)!
-        let mockServiceConfig = OKTServiceConfiguration(authorizationEndpoint: fooURL, tokenEndpoint: fooURL, issuer: fooURL)
+        let mockServiceConfig = makeMockServiceConfig(issuer: fooURL)
         
         let mockTokenRequest = OKTTokenRequest(
                    configuration: mockServiceConfig,

--- a/okta-oidc.xcodeproj/project.pbxproj
+++ b/okta-oidc.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		2F32CCA3229D6801003A6768 /* OktaOidc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F32CA1E229D38D4003A6768 /* OktaOidc.framework */; };
 		2F32CCA4229D6A4E003A6768 /* OktaOidc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F32CA1E229D38D4003A6768 /* OktaOidc.framework */; };
 		2F32CCA8229D6B59003A6768 /* OktaOidc.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2F32CA1E229D38D4003A6768 /* OktaOidc.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		92B62A2D25C41E59002CE64F /* OKTTokensAuthMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B62A2C25C41E59002CE64F /* OKTTokensAuthMock.swift */; };
+		92B62A2E25C41E59002CE64F /* OKTTokensAuthMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B62A2C25C41E59002CE64F /* OKTTokensAuthMock.swift */; };
 		9601C34C256DD14800C084F5 /* OktaRedirectServerConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A167889D2433C7B500D1651D /* OktaRedirectServerConfigurationTests.swift */; };
 		9601C34D256DD14800C084F5 /* OktaOidcBrowserTaskMACTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A167889F2433D0DB00D1651D /* OktaOidcBrowserTaskMACTests.swift */; };
 		9601C34E256DD14800C084F5 /* OktaOidcSignOutHandlerMACTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16788A62435250700D1651D /* OktaOidcSignOutHandlerMACTests.swift */; };
@@ -369,6 +371,7 @@
 		2F32CC8A229D4FCD003A6768 /* Okta_UITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Okta_UITests.swift; sourceTree = "<group>"; };
 		2F32CC8B229D4FCD003A6768 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2F32CC8C229D4FCD003A6768 /* UITestUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITestUtils.swift; sourceTree = "<group>"; };
+		92B62A2C25C41E59002CE64F /* OKTTokensAuthMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKTTokensAuthMock.swift; sourceTree = "<group>"; };
 		960961F925672EC40077978A /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		9671A102256F153900D0B03F /* OktaOidcBrowserProtocolIOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OktaOidcBrowserProtocolIOS.swift; path = Internal/OktaOidcBrowserProtocolIOS.swift; sourceTree = "<group>"; };
 		9671A103256F153900D0B03F /* OktaOidc+BrowserIOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OktaOidc+BrowserIOS.swift"; sourceTree = "<group>"; };
@@ -757,6 +760,7 @@
 				A16788C02436B1DF00D1651D /* OKTExternalUserAgentSessionMock.swift */,
 				A167889B2432CDD700D1651D /* OKTRedirectHTTPHandlerMock.swift */,
 				DEBFB8E72507C53600A27026 /* URLSessionMock.swift */,
+				92B62A2C25C41E59002CE64F /* OKTTokensAuthMock.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1391,6 +1395,7 @@
 				A17E3A162358FA3300837873 /* OKTRPProfileCode.m in Sources */,
 				A17E3A102358FA3200837873 /* OKTAuthorizationResponseTests.m in Sources */,
 				A17E3A122358FA3300837873 /* OKTURLQueryComponentTestsIOS7.m in Sources */,
+				92B62A2D25C41E59002CE64F /* OKTTokensAuthMock.swift in Sources */,
 				A17E3A202358FA3300837873 /* OKTTokenUtilitiesTests.m in Sources */,
 				2F32CC40229D4D11003A6768 /* OktaOidcKeychainTests.swift in Sources */,
 				9601C372256DD25900C084F5 /* OKTExternalUserAgentMacMock.swift in Sources */,
@@ -1507,6 +1512,7 @@
 				9601C37B256DD25A00C084F5 /* OktaNetworkRequestCustomizationDelegateMock.swift in Sources */,
 				9601C35D256DD14900C084F5 /* OktaOidcDiscoveryTaskTests.swift in Sources */,
 				9601C355256DD14900C084F5 /* OktaOIDAuthStateTests.swift in Sources */,
+				92B62A2E25C41E59002CE64F /* OKTTokensAuthMock.swift in Sources */,
 				9601C35B256DD14900C084F5 /* OktaOidcBrowserTaskIOSTests.swift in Sources */,
 				A16788C72436B8DB00D1651D /* OktaOidcBrowserTests.swift in Sources */,
 				9601C357256DD14900C084F5 /* OktaOidcEndpointTests.swift in Sources */,

--- a/scripts/carthage-xcode-12.sh
+++ b/scripts/carthage-xcode-12.sh
@@ -1,0 +1,19 @@
+# carthage.sh
+# Usage example: ./carthage.sh build --platform iOS
+
+set -euo pipefail
+
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+
+CURRENT_XCODE_VERSION=$(xcodebuild -version | grep "Build version" | cut -d' ' -f3)
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$CURRENT_XCODE_VERSION = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
+
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+
+export XCODE_XCCONFIG_FILE="$xcconfig"
+carthage "$@"


### PR DESCRIPTION
### Problem Analysis (Technical)
The iOS OIDC SDK currently supports OTRF (one-time refresh token), but there are no unit tests written to explicitly capture that workflow.
The access token and id token are not covered by unit tests. 

### Solution (Technical)
Write unit tests to verify that a client's state is updated when a refresh token changes. Assure that access and id tokens are returned correctly based on AuthState' state. 

### Affected Components
`OktaOidcStateManager`


### Tests
See `OktaOidcStateManagerTests`