### PR TITLE
Ensure the network request customization delegate is maintained or resettable when relaunching the application

### DIFF
--- a/Sources/OktaOidc/Common/Internal/OIDAuthState+Okta.swift
+++ b/Sources/OktaOidc/Common/Internal/OIDAuthState+Okta.swift
@@ -43,7 +43,10 @@ extension OKTAuthState {
                     return
                 }
 
-                let authState = OKTAuthState(authorizationResponse: authResponse, tokenResponse: tokenResponse)
+                let authState = OKTAuthState(authorizationResponse: authResponse,
+                                             tokenResponse: tokenResponse,
+                                             registrationResponse: nil,
+                                             delegate: delegate)
                 finalize(authState, nil)
             })
         })

--- a/Sources/OktaOidc/Common/OktaOidc.swift
+++ b/Sources/OktaOidc/Common/OktaOidc.swift
@@ -46,7 +46,7 @@ public class OktaOidc: NSObject {
 
                 let authStateManager = OktaOidcStateManager(authState: authState)
                 if let delegate = self.configuration.requestCustomizationDelegate {
-                    authStateManager.restAPI.requestCustomizationDelegate = delegate
+                    authStateManager.requestCustomizationDelegate = delegate
                 }
                 callback(authStateManager, nil)
             })
@@ -69,7 +69,7 @@ public class OktaOidc: NSObject {
             
             let authStateManager = OktaOidcStateManager(authState: authState)
             if let delegate = self?.configuration.requestCustomizationDelegate {
-                authStateManager.restAPI.requestCustomizationDelegate = delegate
+                authStateManager.requestCustomizationDelegate = delegate
             }
             callback(authStateManager, nil)
         }

--- a/Sources/OktaOidc/Common/OktaOidcStateManager.swift
+++ b/Sources/OktaOidc/Common/OktaOidcStateManager.swift
@@ -23,6 +23,15 @@ open class OktaOidcStateManager: NSObject, NSSecureCoding {
     @objc open var authState: OKTAuthState
     @objc open var accessibility: CFString
 
+    @objc public weak var requestCustomizationDelegate: OktaNetworkRequestCustomizationDelegate? {
+        get {
+            restAPI.requestCustomizationDelegate
+        }
+        set {
+            restAPI.requestCustomizationDelegate = newValue
+        }
+    }
+
     @objc open var accessToken: String? {
         // Return the known accessToken if it hasn't expired
         guard let tokenResponse = self.authState.lastTokenResponse,

--- a/Tests/Common/URLSessionMock.swift
+++ b/Tests/Common/URLSessionMock.swift
@@ -29,19 +29,28 @@ class URLSessionDataTaskMock: URLSessionDataTask {
 }
 
 class URLSessionMock: URLSession {
+    
+    struct Response {
+        var statusCode: Int = 200
+        var headerFields: [String : String]?
+        var data = Data()
+    }
 
     var request: URLRequest?
-
+    var responses: [Response]?
+    
     override func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
         self.request = request
+        let responseData = responses?.removeFirst() ?? Response()
+        
         let response = HTTPURLResponse(
             url: request.url!,
-            statusCode: 200,
+            statusCode: responseData.statusCode,
             httpVersion: nil,
-            headerFields: nil
+            headerFields: responseData.headerFields
         )
         return URLSessionDataTaskMock() {
-            completionHandler(Data(), response, nil)
+            completionHandler(responseData.data, response, nil)
         }
     }
 }

--- a/Tests/Common/URLSessionMock.swift
+++ b/Tests/Common/URLSessionMock.swift
@@ -32,7 +32,7 @@ class URLSessionMock: URLSession {
     
     struct Response {
         var statusCode: Int = 200
-        var headerFields: [String : String]?
+        var headerFields: [String: String]?
         var data = Data()
     }
 

--- a/Tests/OktaOidcTests/OktaOidcStateManagerTests.swift
+++ b/Tests/OktaOidcTests/OktaOidcStateManagerTests.swift
@@ -316,6 +316,14 @@ class OktaOidcStateManagerTests: XCTestCase {
         XCTAssertNotEqual(authStateManager.idToken, authStateManager.authState.lastTokenResponse?.idToken)
     }
     
+    func testSetDelegate() {
+        let authState = TestUtils.setupMockAuthState(issuer: TestUtils.mockIssuer, clientId: TestUtils.mockClientId, skipTokenResponse: true)
+        let stateManager = OktaOidcStateManager(authState: authState)
+        let delegateMock = OktaNetworkRequestCustomizationDelegateMock()
+        stateManager.requestCustomizationDelegate = delegateMock
+        XCTAssertEqual(stateManager.restAPI.requestCustomizationDelegate as? OktaNetworkRequestCustomizationDelegateMock, delegateMock)
+    }
+
     #if !SWIFT_PACKAGE
     /// **Note:** Unit tests in Swift Package Manager do not support tests run from a host application, meaning some iOS features are unavailable.
     func testReadWriteToSecureStorage() {


### PR DESCRIPTION
### Problem Analysis (Technical)

In issues #287, there are circumstances where the OktaNetworkRequestCustomizationDelegate may become unset, or impossible to re-set, which prevents developers from monitoring or overriding the network request process.

### Solution (Technical)

Two primary changes were introduced:

1. Supply the delegate to the OKTAuthState initializer when it is created using `OKTAuthState.getState`
2. Expose a `delegate` property on the OktaOidcStateManager that permits setting the REST API delegate property, without exposing the full OktaOidcRestApi object.

### Affected Components

OKTAuthState and OktaOidcStateManager.

### Steps to reproduce:

1. Perform `OKTAuthState.getState` with a delegate.
2. Examine the resulting state object.

Actual result:

The delegate value is dropped on the new object.

Expected result:

The delegate should persist in the newly created object.

### Tests

Added unit tests to prove both these new API changes work.