### PR TITLE
Add Session Cookie Redirect

### DIFF
--- a/Sources/AppAuth/OKTAuthorizationRequest.m
+++ b/Sources/AppAuth/OKTAuthorizationRequest.m
@@ -312,9 +312,15 @@ NSString *const OKTOAuthorizationRequestCodeChallengeMethodS256 = @"S256";
   // Required parameters.
   [query addParameter:kResponseTypeKey value:_responseType];
   [query addParameter:kClientIDKey value:_clientID];
+    
+  NSString *sessionCookieURLString = _additionalParameters[kSessionCookieURL];
+  NSURL *sessionCookieURL = [NSURL URLWithString:sessionCookieURLString];
+  NSMutableDictionary *additionalParameters = [_additionalParameters mutableCopy];
+    
+  [additionalParameters removeObjectForKey:kSessionCookieURL];
 
   // Add any additional parameters the client has specified.
-  [query addParameters:_additionalParameters];
+  [query addParameters:additionalParameters];
 
   // Add optional parameters, as applicable.
   if (_redirectURL) {
@@ -334,6 +340,16 @@ NSString *const OKTOAuthorizationRequestCodeChallengeMethodS256 = @"S256";
   }
   if (_codeChallengeMethod) {
     [query addParameter:kCodeChallengeMethodKey value:_codeChallengeMethod];
+  }
+    
+  if(sessionCookieURL) {
+    OKTURLQueryComponent *sessionCookieQuery = [[OKTURLQueryComponent alloc] initWithURL:sessionCookieURL];
+
+    NSURL *discoveryRequest = [query URLByReplacingQueryInURL:_configuration.authorizationEndpoint];
+
+    [sessionCookieQuery addParameter:@"redirect_uri" value:discoveryRequest.absoluteString];
+
+    return [sessionCookieQuery URLByReplacingQueryInURL:sessionCookieURL];
   }
 
   // Construct the URL:

--- a/Sources/AppAuth/OKTAuthorizationRequest.m
+++ b/Sources/AppAuth/OKTAuthorizationRequest.m
@@ -78,6 +78,10 @@ static NSString *const kCodeChallengeMethodKey = @"code_challenge_method";
  */
 static NSString *const kAdditionalParametersKey = @"additionalParameters";
 
+/*! @brief Key used to extract the URL to set a session cookie before redirecting to the authorizationEndpoint
+ */
+static NSString *const kSessionCookieURL = @"sessionCookieURL";
+
 /*! @brief Number of random bytes generated for the @ state.
  */
 static NSUInteger const kStateSizeBytes = 32;


### PR DESCRIPTION
### Problem Analysis (Technical)
In order to customize the look and feel of the Okta Login page, it was suggested by Okta to our Identity and Access Management team to use a session cookie redirect
https://developer.okta.com/docs/guides/session-cookie/overview/#retrieving-a-session-cookie-by-visiting-a-session-redirect-link

We implemented this on the web, so we visit the session cookie url, which sets a cooke, then redirects to the okta login page.

However, there doesn't appear to be a way to do this with the mobile libraries.

### Solution (Technical)
Pass "sessionCookieURL" with additionalParmaters
When constructing the AuthorizationRequest, if "sessionCookieURL" is present, store it in a variable
Remove "sessionCookieURL" from additionalParameters (you don't want to add it as a param while building the authorization request).
Build the authorization request
Add a "redirect_uri" param to the sessionCookieURL, with value equal to the authorization request.

This will open a browser with the flow:

sessionCookieURL -> set cookie -> redirect -> authorization request

### Affected Components
OKTAuthorizationRequest


### Tests
Will add tests soon, but would like feedback if this is a sensible approach for issue #292 
