### PR TITLE
Data read write by okta OIDC is not compatible between versions

### DIFF
--- a/Sources/OktaOidc/Common/OktaOidcStateManager.swift
+++ b/Sources/OktaOidc/Common/OktaOidcStateManager.swift
@@ -214,6 +214,18 @@ open class OktaOidcStateManager: NSObject, NSSecureCoding {
 
         let state: OktaOidcStateManager?
         if #available(iOS 11, OSX 10.14, *) {
+          let classes = [OKTAuthorizationRequest.self, OKTAuthorizationResponse.self,
+                         OKTAuthState.self, OKTEndSessionRequest.self,
+                         OKTEndSessionResponse.self, OKTRegistrationRequest.self,
+                         OKTRegistrationResponse.self, OKTServiceConfiguration.self,
+                         OKTServiceDiscovery.self, OKTTokenRequest.self,
+                         OKTTokenResponse.self]
+          
+          for archivedClass in classes {
+            let className = "\(archivedClass)".replacingOccurrences(of: "OKT", with: "OID")
+            NSKeyedUnarchiver.setClass(archivedClass, forClassName: className)
+          }
+
             state = (try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(encodedAuthState)) as? OktaOidcStateManager
         } else {
             state = NSKeyedUnarchiver.unarchiveObject(with: encodedAuthState) as? OktaOidcStateManager

--- a/Sources/OktaOidc/Common/OktaOidcStateManager.swift
+++ b/Sources/OktaOidc/Common/OktaOidcStateManager.swift
@@ -191,8 +191,6 @@ open class OktaOidcStateManager: NSObject, NSSecureCoding {
     @objc func writeToSecureStorage() {
         let authStateData: Data
         do {
-            prepareKeyedArchiver()
-          
             if #available(iOS 11, OSX 10.14, *) {
                 authStateData = try NSKeyedArchiver.archivedData(withRootObject: self, requiringSecureCoding: false)
             } else {
@@ -215,6 +213,8 @@ open class OktaOidcStateManager: NSObject, NSSecureCoding {
         }
 
         let state: OktaOidcStateManager?
+        prepareKeyedArchiver()
+      
         if #available(iOS 11, OSX 10.14, *) {
             state = (try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(encodedAuthState)) as? OktaOidcStateManager
         } else {
@@ -226,7 +226,7 @@ open class OktaOidcStateManager: NSObject, NSSecureCoding {
   
     /// This method can be removed in the future with release 4.0.0 or higher.
     /// Resolves OKTA-427089
-    private func prepareKeyedArchiver() {
+    private static func prepareKeyedArchiver() {
         let classes = [OKTAuthorizationRequest.self, OKTAuthorizationResponse.self,
                        OKTAuthState.self, OKTEndSessionRequest.self,
                        OKTEndSessionResponse.self, OKTRegistrationRequest.self,

--- a/Sources/OktaOidc/Common/OktaOidcStateManager.swift
+++ b/Sources/OktaOidc/Common/OktaOidcStateManager.swift
@@ -191,6 +191,8 @@ open class OktaOidcStateManager: NSObject, NSSecureCoding {
     @objc func writeToSecureStorage() {
         let authStateData: Data
         do {
+            prepareKeyedArchiver()
+          
             if #available(iOS 11, OSX 10.14, *) {
                 authStateData = try NSKeyedArchiver.archivedData(withRootObject: self, requiringSecureCoding: false)
             } else {
@@ -214,24 +216,28 @@ open class OktaOidcStateManager: NSObject, NSSecureCoding {
 
         let state: OktaOidcStateManager?
         if #available(iOS 11, OSX 10.14, *) {
-          let classes = [OKTAuthorizationRequest.self, OKTAuthorizationResponse.self,
-                         OKTAuthState.self, OKTEndSessionRequest.self,
-                         OKTEndSessionResponse.self, OKTRegistrationRequest.self,
-                         OKTRegistrationResponse.self, OKTServiceConfiguration.self,
-                         OKTServiceDiscovery.self, OKTTokenRequest.self,
-                         OKTTokenResponse.self]
-          
-          for archivedClass in classes {
-            let className = "\(archivedClass)".replacingOccurrences(of: "OKT", with: "OID")
-            NSKeyedUnarchiver.setClass(archivedClass, forClassName: className)
-          }
-
             state = (try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(encodedAuthState)) as? OktaOidcStateManager
         } else {
             state = NSKeyedUnarchiver.unarchiveObject(with: encodedAuthState) as? OktaOidcStateManager
         }
 
         return state
+    }
+  
+    /// This method can be removed in the future with release 4.0.0 or higher.
+    /// Resolves OKTA-427089
+    private func prepareKeyedArchiver() {
+        let classes = [OKTAuthorizationRequest.self, OKTAuthorizationResponse.self,
+                       OKTAuthState.self, OKTEndSessionRequest.self,
+                       OKTEndSessionResponse.self, OKTRegistrationRequest.self,
+                       OKTRegistrationResponse.self, OKTServiceConfiguration.self,
+                       OKTServiceDiscovery.self, OKTTokenRequest.self,
+                       OKTTokenResponse.self]
+        
+        for archivedClass in classes {
+            let className = "\(archivedClass)".replacingOccurrences(of: "OKT", with: "OID")
+            NSKeyedUnarchiver.setClass(archivedClass, forClassName: className)
+        }
     }
 }
 


### PR DESCRIPTION
### Problem Analysis (Technical)
Data read/write by OktaOidc is not compatible between versions , iOS SDK version 3.9.1  to 3.10.4. The problem is in renamed files in https://github.com/okta/okta-oidc-ios/pull/249/files. 

### Solution (Technical)
Fixed by using `NSKeyedUnarchiver.setClass(:forClassName:)`. 

### Affected Components
`OktaOidcStateManager.swift`

### Tests

No unit tests written because of issue trickiness. Manual testing verifies this fix. 
