### PR TITLE
Set pipefail option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ osx_image: xcode12.5
 before_install:
   - gem install xcpretty
   - gem install cocoapods
+  - set -eo pipefail
 jobs:
   include:
     - stage: Linting


### PR DESCRIPTION
The reason of setting this option is that xcpretty may overlap failed test. So CI shows tests passed.

https://github.com/xcpretty/xcpretty#usage
