### PR TITLE
Generic error code is returned for all authorization

### DIFF
--- a/Example/AuthViewController.swift
+++ b/Example/AuthViewController.swift
@@ -48,7 +48,7 @@ final class AuthViewController: UIViewController {
             self.hideProgress()
             
             if let error = error {
-                self.showError(error)
+                self.showMessage(error)
                 return
             }
             
@@ -57,9 +57,9 @@ final class AuthViewController: UIViewController {
         }
     }
     
-    func showError(_ error: Error) {
+    func showMessage(_ error: Error) {
         if let oidcError = error as? OktaOidcError {
-            messageView.text = UIViewController.displayErrorMessage(oidcError)
+            messageView.text = oidcError.displayMessage
         } else {
             messageView.text = error.localizedDescription
         }

--- a/Example/AuthViewController.swift
+++ b/Example/AuthViewController.swift
@@ -46,8 +46,9 @@ final class AuthViewController: UIViewController {
         showProgress()
         oktaAppAuth?.authenticate(withSessionToken: token) { authStateManager, error in
             self.hideProgress()
+            
             if let error = error {
-                self.presentError(error)
+                self.showError(error)
                 return
             }
             
@@ -56,8 +57,12 @@ final class AuthViewController: UIViewController {
         }
     }
     
-    func presentError(_ error: Error) {
-        self.showMessage("Error: \(error.localizedDescription)")
+    func showError(_ error: Error) {
+        if let oidcError = error as? OktaOidcError {
+            messageView.text = UIViewController.displayErrorMessage(oidcError)
+        } else {
+            messageView.text = error.localizedDescription
+        }
     }
     
     func showMessage(_ message: String) {

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -143,7 +143,7 @@ final class ViewController: UIViewController {
         oktaAppAuth?.signInWithBrowser(from: self) { authStateManager, error in
             if let error = error {
                 self.authStateManager = nil
-                self.updateUI(updateText: "Error: \(error)")
+                self.updateUI(updateText: "Error: \(error.localizedDescription)")
                 return
             }
             

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -65,7 +65,7 @@ final class ViewController: UIViewController {
         super.viewWillAppear(animated)
         
         guard oktaAppAuth != nil else {
-            self.updateUI(updateText: "SDK is not configured!")
+            self.showMessage("SDK is not configured!")
             return
         }
         
@@ -103,14 +103,14 @@ final class ViewController: UIViewController {
     @IBAction func userInfoButton(_ sender: Any) {
         authStateManager?.getUser() { response, error in
             if let error = error {
-                self.showError(error)
+                self.showMessage(error)
                 return
             }
 
             if response != nil {
                 var userInfoText = ""
                 response?.forEach { userInfoText += ("\($0): \($1) \n") }
-                self.updateUI(updateText: userInfoText)
+                self.showMessage(userInfoText)
             }
         }
     }
@@ -121,11 +121,11 @@ final class ViewController: UIViewController {
 
         authStateManager?.introspect(token: accessToken, callback: { payload, error in
             guard let isValid = payload?["active"] as? Bool else {
-                self.updateUI(updateText: "Error: \(error?.localizedDescription ?? "Unknown")")
+                self.showMessage("Error: \(error?.localizedDescription ?? "Unknown")")
                 return
             }
             
-            self.updateUI(updateText: "Is the AccessToken valid? - \(isValid)")
+            self.showMessage("Is the AccessToken valid? - \(isValid)")
         })
     }
 
@@ -134,8 +134,8 @@ final class ViewController: UIViewController {
         guard let accessToken = authStateManager?.accessToken else { return }
 
         authStateManager?.revoke(accessToken) { _, error in
-            if error != nil { self.updateUI(updateText: "Error: \(error!)") }
-            self.updateUI(updateText: "AccessToken was revoked")
+            if error != nil { self.showMessage("Error: \(error!)") }
+            self.showMessage("AccessToken was revoked")
         }
     }
 
@@ -143,7 +143,7 @@ final class ViewController: UIViewController {
         oktaAppAuth?.signInWithBrowser(from: self) { authStateManager, error in
             if let error = error {
                 self.authStateManager = nil
-                self.updateUI(updateText: "Error: \(error.localizedDescription)")
+                self.showMessage("Error: \(error.localizedDescription)")
                 return
             }
             
@@ -158,9 +158,9 @@ final class ViewController: UIViewController {
         oktaAppAuth?.signOut(authStateManager: authStateManager, from: self, progressHandler: { currentOption in
             switch currentOption {
             case .revokeAccessToken, .revokeRefreshToken, .removeTokensFromStorage, .revokeTokensOptions:
-                self.updateUI(updateText: "Revoking tokens...")
+                self.showMessage("Revoking tokens...")
             case .signOutFromOkta:
-                self.updateUI(updateText: "Signing out from Okta...")
+                self.showMessage("Signing out from Okta...")
             default:
                 break
             }
@@ -169,18 +169,18 @@ final class ViewController: UIViewController {
                 self.authStateManager = nil
                 self.buildTokenTextView()
             } else {
-                self.updateUI(updateText: "Error: failed to logout")
+                self.showMessage("Error: failed to logout")
             }
         })
     }
     
-    func updateUI(updateText: String) {
-        tokenView.text = updateText
+    func showMessage(_ message: String) {
+        tokenView.text = message
     }
     
-    func showError(_ error: Error) {
+    func showMessage(_ error: Error) {
         if let oidcError = error as? OktaOidcError {
-            tokenView.text = UIViewController.displayErrorMessage(oidcError)
+            tokenView.text = oidcError.displayMessage
         } else {
             tokenView.text = error.localizedDescription
         }
@@ -205,7 +205,7 @@ final class ViewController: UIViewController {
             tokenString += "\nRefresh Token: \(refreshToken)\n"
         }
 
-        self.updateUI(updateText: tokenString)
+        self.showMessage(tokenString)
     }
 }
 
@@ -224,11 +224,11 @@ extension ViewController: OktaNetworkRequestCustomizationDelegate {
     }
 }
 
-extension UIViewController {
-    static func displayErrorMessage(_ error: OktaOidcError) -> String {
-        switch error {
+extension OktaOidcError {
+    var displayMessage: String {
+        switch self {
         case let .api(message, _):
-            switch (error as NSError).code {
+            switch (self as NSError).code {
             case NSURLErrorNotConnectedToInternet,
                 NSURLErrorNetworkConnectionLost,
                 NSURLErrorCannotLoadFromNetwork,
@@ -246,7 +246,7 @@ extension UIViewController {
         case let .unexpectedAuthCodeResponse(statusCode):
             return "Authorization failed due to incorrect status code: \(statusCode)"
         default:
-            return error.localizedDescription
+            return localizedDescription
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can learn more on the [Okta + iOS](https://developer.okta.com/code/ios/) pag
 - [Development](#development)
   - [Running Tests](#running-tests)
 - [Modify network requests](#modify-network-requests)
+- [Migration](#migration)
 - [Known issues](#known-issues)
 - [Contributing](#contributing)
 
@@ -506,6 +507,20 @@ extension SomeNSObject: OktaNetworkRequestCustomizationDelegate {
 ```
 
 ***Note:*** It is highly recommended to copy all of the existing parameters from the original URLRequest object to modified request without any changes. Altering of this data could lead network request to fail. If `customizableURLRequest(_:)` method returns `nil` default request will be used.
+
+## Migration
+
+### Migrating from 3.10.x to 3.11.x
+
+The SDK `okta-oidc-ios` has a major changes in error handling. Consider these guidelines to update your code.
+
+- `APIError` is renamed as `api`.
+- `api` error has the additional parameter `underlyingError`, it's an optional and indicates the origin of the error.
+- Introduced a new error `authorization(error:description:)`.
+- `authorization` error appears when authorization server fails due to errors during authorization.
+- `unexpectedAuthCodeResponse(statusCode:)` has an error code parameter.
+- `OktaOidcError` conforms to `CustomNSError` protocol. It means you can convert the error to `NSError` and get `code`, `userInfo`, `domain`, `underlyingErrors`.
+- `OktaOidcError` conforms to `Equatable` protocol. The errors can be compared for equality using the operator `==` or inequality using the operator `!=`.
 
 ## Known issues
 

--- a/Sources/OktaOidc/Common/Internal/OIDAuthState+Okta.swift
+++ b/Sources/OktaOidc/Common/Internal/OIDAuthState+Okta.swift
@@ -17,27 +17,29 @@ import OktaOidc_AppAuth
 // Okta Extension of OIDAuthState
 extension OKTAuthState {
 
-    static func getState(withAuthRequest authRequest: OKTAuthorizationRequest, delegate: OktaNetworkRequestCustomizationDelegate? = nil, callback: @escaping (OKTAuthState?, OktaOidcError?) -> Void ) {
+    static func getState(withAuthRequest authRequest: OKTAuthorizationRequest, delegate: OktaNetworkRequestCustomizationDelegate? = nil, callback finalize: @escaping (OKTAuthState?, OktaOidcError?) -> Void ) {
         
-        let finalize: ((OKTAuthState?, OktaOidcError?) -> Void) = { state, error in
-            callback(state, error)
-        }
-
         // Make authCode request
-        OKTAuthorizationService.perform(authRequest: authRequest, delegate: delegate, callback: { authResponse, error in
+        OKTAuthorizationService.perform(authRequest: authRequest, delegate: delegate) { authResponse, error in
             guard let authResponse = authResponse else {
-                finalize(nil, OktaOidcError.api(message: "Authorization Error: \(error?.localizedDescription ?? "No authentication response.")", underlyingError: error))
+                finalize(nil, .api(message: "Authorization Error: \(error?.localizedDescription ?? "No authentication response.")", underlyingError: error))
                 return
             }
-
+            
+            if let oauthError = authResponse.additionalParameters?[OKTOAuthErrorFieldError] as? String {
+                let oauthErrorDescription = authResponse.additionalParameters?[OKTOAuthErrorFieldErrorDescription] as? String
+                finalize(nil, .authorization(error: oauthError, description: oauthErrorDescription))
+                return
+            }
+            
             guard authResponse.authorizationCode != nil,
                   let tokenRequest = authResponse.tokenExchangeRequest() else {
-                    finalize(nil, OktaOidcError.unableToGetAuthCode)
+                    finalize(nil, .unableToGetAuthCode)
                     return
             }
 
             // Make token request
-            OKTAuthorizationService.perform(tokenRequest, originalAuthorizationResponse: authResponse, delegate: delegate, callback: { tokenResponse, error in
+            OKTAuthorizationService.perform(tokenRequest, originalAuthorizationResponse: authResponse, delegate: delegate) { tokenResponse, error in
                 guard let tokenResponse = tokenResponse else {
                     finalize(nil, OktaOidcError.api(message: "Authorization Error: \(error?.localizedDescription ?? "No token response.")", underlyingError: error))
                     return
@@ -48,7 +50,7 @@ extension OKTAuthState {
                                              registrationResponse: nil,
                                              delegate: delegate)
                 finalize(authState, nil)
-            })
-        })
+            }
+        }
     }
 }

--- a/Sources/OktaOidc/Common/Internal/OIDAuthState+Okta.swift
+++ b/Sources/OktaOidc/Common/Internal/OIDAuthState+Okta.swift
@@ -26,7 +26,7 @@ extension OKTAuthState {
         // Make authCode request
         OKTAuthorizationService.perform(authRequest: authRequest, delegate: delegate, callback: { authResponse, error in
             guard let authResponse = authResponse else {
-                finalize(nil, OktaOidcError.api(message: "Authorization Error: \(error?.localizedDescription ?? "No authentication response.")", underlineError: error))
+                finalize(nil, OktaOidcError.api(message: "Authorization Error: \(error?.localizedDescription ?? "No authentication response.")", underlyingError: error))
                 return
             }
 
@@ -39,7 +39,7 @@ extension OKTAuthState {
             // Make token request
             OKTAuthorizationService.perform(tokenRequest, originalAuthorizationResponse: authResponse, delegate: delegate, callback: { tokenResponse, error in
                 guard let tokenResponse = tokenResponse else {
-                    finalize(nil, OktaOidcError.api(message: "Authorization Error: \(error?.localizedDescription ?? "No token response.")", underlineError: error))
+                    finalize(nil, OktaOidcError.api(message: "Authorization Error: \(error?.localizedDescription ?? "No token response.")", underlyingError: error))
                     return
                 }
 

--- a/Sources/OktaOidc/Common/Internal/OIDAuthState+Okta.swift
+++ b/Sources/OktaOidc/Common/Internal/OIDAuthState+Okta.swift
@@ -26,7 +26,7 @@ extension OKTAuthState {
         // Make authCode request
         OKTAuthorizationService.perform(authRequest: authRequest, delegate: delegate, callback: { authResponse, error in
             guard let authResponse = authResponse else {
-                finalize(nil, OktaOidcError.APIError("Authorization Error: \(error?.localizedDescription ?? "No authentication response.")"))
+                finalize(nil, OktaOidcError.api(message: "Authorization Error: \(error?.localizedDescription ?? "No authentication response.")", underlineError: error))
                 return
             }
 
@@ -39,7 +39,7 @@ extension OKTAuthState {
             // Make token request
             OKTAuthorizationService.perform(tokenRequest, originalAuthorizationResponse: authResponse, delegate: delegate, callback: { tokenResponse, error in
                 guard let tokenResponse = tokenResponse else {
-                    finalize(nil, OktaOidcError.APIError("Authorization Error: \(error?.localizedDescription ?? "No token response.")"))
+                    finalize(nil, OktaOidcError.api(message: "Authorization Error: \(error?.localizedDescription ?? "No token response.")", underlineError: error))
                     return
                 }
 

--- a/Sources/OktaOidc/Common/Internal/OIDAuthState+Okta.swift
+++ b/Sources/OktaOidc/Common/Internal/OIDAuthState+Okta.swift
@@ -44,6 +44,12 @@ extension OKTAuthState {
                     finalize(nil, OktaOidcError.api(message: "Authorization Error: \(error?.localizedDescription ?? "No token response.")", underlyingError: error))
                     return
                 }
+                
+                if let oauthError = tokenResponse.additionalParameters?[OKTOAuthErrorFieldError] as? String {
+                    let oauthErrorDescription = tokenResponse.additionalParameters?[OKTOAuthErrorFieldErrorDescription] as? String
+                    finalize(nil, .authorization(error: oauthError, description: oauthErrorDescription))
+                    return
+                }
 
                 let authState = OKTAuthState(authorizationResponse: authResponse,
                                              tokenResponse: tokenResponse,

--- a/Sources/OktaOidc/Common/Internal/OIDAuthorizationService+Okta.swift
+++ b/Sources/OktaOidc/Common/Internal/OIDAuthorizationService+Okta.swift
@@ -35,7 +35,7 @@ extension OKTAuthorizationService {
 
             delegate?.didReceive(response)
             guard let response = response as? HTTPURLResponse else {
-                callback(nil, error ?? OktaOidcError.api(message: "Authentication Error: No response", underlyingError: error))
+                callback(nil, error ?? OktaOidcError.api(message: "Authentication Error: No response", underlyingError: nil))
                 return
             }
             

--- a/Sources/OktaOidc/Common/Internal/OIDAuthorizationService+Okta.swift
+++ b/Sources/OktaOidc/Common/Internal/OIDAuthorizationService+Okta.swift
@@ -35,7 +35,7 @@ extension OKTAuthorizationService {
 
             delegate?.didReceive(response)
             guard let response = response as? HTTPURLResponse else {
-                callback(nil, error ?? OktaOidcError.APIError("Authentication Error: No response"))
+                callback(nil, error ?? OktaOidcError.api(message: "Authentication Error: No response", underlineError: error))
                 return
             }
             

--- a/Sources/OktaOidc/Common/Internal/OIDAuthorizationService+Okta.swift
+++ b/Sources/OktaOidc/Common/Internal/OIDAuthorizationService+Okta.swift
@@ -35,7 +35,7 @@ extension OKTAuthorizationService {
 
             delegate?.didReceive(response)
             guard let response = response as? HTTPURLResponse else {
-                callback(nil, OktaOidcError.api(message: "Authentication Error: No response", underlyingError: nil))
+                callback(nil, OktaOidcError.api(message: "Authentication Error: No response", underlyingError: error))
                 return
             }
             

--- a/Sources/OktaOidc/Common/Internal/OIDAuthorizationService+Okta.swift
+++ b/Sources/OktaOidc/Common/Internal/OIDAuthorizationService+Okta.swift
@@ -35,7 +35,7 @@ extension OKTAuthorizationService {
 
             delegate?.didReceive(response)
             guard let response = response as? HTTPURLResponse else {
-                callback(nil, error ?? OktaOidcError.api(message: "Authentication Error: No response", underlyingError: nil))
+                callback(nil, OktaOidcError.api(message: "Authentication Error: No response", underlyingError: nil))
                 return
             }
             

--- a/Sources/OktaOidc/Common/Internal/OIDAuthorizationService+Okta.swift
+++ b/Sources/OktaOidc/Common/Internal/OIDAuthorizationService+Okta.swift
@@ -35,7 +35,7 @@ extension OKTAuthorizationService {
 
             delegate?.didReceive(response)
             guard let response = response as? HTTPURLResponse else {
-                callback(nil, error ?? OktaOidcError.api(message: "Authentication Error: No response", underlineError: error))
+                callback(nil, error ?? OktaOidcError.api(message: "Authentication Error: No response", underlyingError: error))
                 return
             }
             

--- a/Sources/OktaOidc/Common/Internal/OIDAuthorizationService+Okta.swift
+++ b/Sources/OktaOidc/Common/Internal/OIDAuthorizationService+Okta.swift
@@ -35,15 +35,15 @@ extension OKTAuthorizationService {
 
             delegate?.didReceive(response)
             guard let response = response as? HTTPURLResponse else {
-                callback(nil, error)
+                callback(nil, error ?? OktaOidcError.APIError("Authentication Error: No response"))
                 return
             }
             
             guard response.statusCode == 302,
                   let locationHeader = response.allHeaderFields["Location"] as? String,
-                  let urlComonents = URLComponents(string: locationHeader),
-                  let queryItems = urlComonents.queryItems else {
-                    callback(nil, OktaOidcError.unexpectedAuthCodeResponse)
+                  let urlComponents = URLComponents(string: locationHeader),
+                  let queryItems = urlComponents.queryItems else {
+                      callback(nil, OktaOidcError.unexpectedAuthCodeResponse(statusCode: response.statusCode))
                     return
             }
         

--- a/Sources/OktaOidc/Common/Internal/OktaOidcRestApi.swift
+++ b/Sources/OktaOidc/Common/Internal/OktaOidcRestApi.swift
@@ -28,14 +28,14 @@ class OktaOidcRestApi: OktaOidcHttpApiProtocol {
                   let httpResponse = response as? HTTPURLResponse else {
                 let errorMessage = error?.localizedDescription ?? "No response data"
                 DispatchQueue.main.async {
-                    onError(OktaOidcError.api(message: errorMessage, underlineError: error))
+                    onError(OktaOidcError.api(message: errorMessage, underlyingError: error))
                 }
                 return
             }
 
             guard 200 ..< 300 ~= httpResponse.statusCode else {
                 DispatchQueue.main.async {
-                    onError(OktaOidcError.api(message: HTTPURLResponse.localizedString(forStatusCode: httpResponse.statusCode), underlineError: nil))
+                    onError(OktaOidcError.api(message: HTTPURLResponse.localizedString(forStatusCode: httpResponse.statusCode), underlyingError: nil))
                 }
                 return
             }

--- a/Sources/OktaOidc/Common/Internal/OktaOidcRestApi.swift
+++ b/Sources/OktaOidc/Common/Internal/OktaOidcRestApi.swift
@@ -28,14 +28,14 @@ class OktaOidcRestApi: OktaOidcHttpApiProtocol {
                   let httpResponse = response as? HTTPURLResponse else {
                 let errorMessage = error?.localizedDescription ?? "No response data"
                 DispatchQueue.main.async {
-                    onError(OktaOidcError.APIError(errorMessage))
+                    onError(OktaOidcError.api(message: errorMessage, underlineError: error))
                 }
                 return
             }
 
             guard 200 ..< 300 ~= httpResponse.statusCode else {
                 DispatchQueue.main.async {
-                    onError(OktaOidcError.APIError(HTTPURLResponse.localizedString(forStatusCode: httpResponse.statusCode)))
+                    onError(OktaOidcError.api(message: HTTPURLResponse.localizedString(forStatusCode: httpResponse.statusCode), underlineError: nil))
                 }
                 return
             }

--- a/Sources/OktaOidc/Common/Internal/Tasks/OktaOidcBrowserTask.swift
+++ b/Sources/OktaOidc/Common/Internal/Tasks/OktaOidcBrowserTask.swift
@@ -55,7 +55,7 @@ class OktaOidcBrowserTask: OktaOidcTask {
                 }
                 
                 guard let error = error else {
-                    callback(nil, OktaOidcError.api(message: "Authorization Error: No authorization response", underlyingError: error))
+                    callback(nil, OktaOidcError.api(message: "Authorization Error: No authorization response", underlyingError: nil))
                     return
                 }
                 
@@ -64,7 +64,7 @@ class OktaOidcBrowserTask: OktaOidcTask {
                     return
                 }
                 
-                return callback(nil, OktaOidcError.api(message: "Authorization Error: \(error.localizedDescription)", underlyingError: nil))
+                return callback(nil, OktaOidcError.api(message: "Authorization Error: \(error.localizedDescription)", underlyingError: error))
             }
             self.userAgentSession = userAgentSession
         }

--- a/Sources/OktaOidc/Common/Internal/Tasks/OktaOidcBrowserTask.swift
+++ b/Sources/OktaOidc/Common/Internal/Tasks/OktaOidcBrowserTask.swift
@@ -40,7 +40,7 @@ class OktaOidcBrowserTask: OktaOidcTask {
                                                   responseType: OKTResponseTypeCode,
                                                   additionalParameters: self.config.additionalParams)
             guard let externalUserAgent = self.externalUserAgent() else {
-                callback(nil, OktaOidcError.api(message: "Authorization Error: \(error?.localizedDescription ?? "No external User Agent.")", underlineError: nil))
+                callback(nil, OktaOidcError.api(message: "Authorization Error: \(error?.localizedDescription ?? "No external User Agent.")", underlyingError: nil))
                 return
             }
 
@@ -55,7 +55,7 @@ class OktaOidcBrowserTask: OktaOidcTask {
                 }
                 
                 guard let error = error else {
-                    callback(nil, OktaOidcError.api(message: "Authorization Error: No authorization response", underlineError: error))
+                    callback(nil, OktaOidcError.api(message: "Authorization Error: No authorization response", underlyingError: error))
                     return
                 }
                 
@@ -64,7 +64,7 @@ class OktaOidcBrowserTask: OktaOidcTask {
                     return
                 }
                 
-                return callback(nil, OktaOidcError.api(message: "Authorization Error: \(error.localizedDescription)", underlineError: nil))
+                return callback(nil, OktaOidcError.api(message: "Authorization Error: \(error.localizedDescription)", underlyingError: nil))
             }
             self.userAgentSession = userAgentSession
         }
@@ -88,7 +88,7 @@ class OktaOidcBrowserTask: OktaOidcTask {
                                                postLogoutRedirectURL: successRedirectURL,
                                                additionalParameters: self.config.additionalParams)
             guard let externalUserAgent = self.externalUserAgent() else {
-                callback(nil, OktaOidcError.api(message: "Authorization Error: \(error?.localizedDescription ?? "No external User Agent.")", underlineError: nil))
+                callback(nil, OktaOidcError.api(message: "Authorization Error: \(error?.localizedDescription ?? "No external User Agent.")", underlyingError: nil))
                 return
             }
             
@@ -97,7 +97,7 @@ class OktaOidcBrowserTask: OktaOidcTask {
                 
                 var error: OktaOidcError?
                 if let responseError = responseError {
-                    error = OktaOidcError.api(message: "Sign Out Error: \(responseError.localizedDescription)", underlineError: nil)
+                    error = OktaOidcError.api(message: "Sign Out Error: \(responseError.localizedDescription)", underlyingError: nil)
                 }
                 
                 callback((), error)

--- a/Sources/OktaOidc/Common/Internal/Tasks/OktaOidcBrowserTask.swift
+++ b/Sources/OktaOidc/Common/Internal/Tasks/OktaOidcBrowserTask.swift
@@ -40,7 +40,7 @@ class OktaOidcBrowserTask: OktaOidcTask {
                                                   responseType: OKTResponseTypeCode,
                                                   additionalParameters: self.config.additionalParams)
             guard let externalUserAgent = self.externalUserAgent() else {
-                callback(nil, OktaOidcError.APIError("Authorization Error: \(error?.localizedDescription ?? "No external User Agent.")"))
+                callback(nil, OktaOidcError.api(message: "Authorization Error: \(error?.localizedDescription ?? "No external User Agent.")", underlineError: nil))
                 return
             }
 
@@ -55,7 +55,7 @@ class OktaOidcBrowserTask: OktaOidcTask {
                 }
                 
                 guard let error = error else {
-                    callback(nil, OktaOidcError.APIError("Authorization Error: No authorization response"))
+                    callback(nil, OktaOidcError.api(message: "Authorization Error: No authorization response", underlineError: error))
                     return
                 }
                 
@@ -64,7 +64,7 @@ class OktaOidcBrowserTask: OktaOidcTask {
                     return
                 }
                 
-                return callback(nil, OktaOidcError.APIError("Authorization Error: \(error.localizedDescription)"))
+                return callback(nil, OktaOidcError.api(message: "Authorization Error: \(error.localizedDescription)", underlineError: nil))
             }
             self.userAgentSession = userAgentSession
         }
@@ -88,7 +88,7 @@ class OktaOidcBrowserTask: OktaOidcTask {
                                                postLogoutRedirectURL: successRedirectURL,
                                                additionalParameters: self.config.additionalParams)
             guard let externalUserAgent = self.externalUserAgent() else {
-                callback(nil, OktaOidcError.APIError("Authorization Error: \(error?.localizedDescription ?? "No external User Agent.")"))
+                callback(nil, OktaOidcError.api(message: "Authorization Error: \(error?.localizedDescription ?? "No external User Agent.")", underlineError: nil))
                 return
             }
             
@@ -97,7 +97,7 @@ class OktaOidcBrowserTask: OktaOidcTask {
                 
                 var error: OktaOidcError?
                 if let responseError = responseError {
-                    error = OktaOidcError.APIError("Sign Out Error: \(responseError.localizedDescription)")
+                    error = OktaOidcError.api(message: "Sign Out Error: \(responseError.localizedDescription)", underlineError: nil)
                 }
                 
                 callback((), error)

--- a/Sources/OktaOidc/Common/Internal/Tasks/OktaOidcBrowserTask.swift
+++ b/Sources/OktaOidc/Common/Internal/Tasks/OktaOidcBrowserTask.swift
@@ -49,17 +49,22 @@ class OktaOidcBrowserTask: OktaOidcTask {
                                                                    delegate: delegate) { authorizationResponse, error in
                 defer { self.userAgentSession = nil }
 
-                guard let authResponse = authorizationResponse else {
-                    guard let error = error else {
-                        return callback(nil, OktaOidcError.APIError("Authorization Error"))
-                    }
-                    if (error as NSError).code == OKTErrorCode.userCanceledAuthorizationFlow.rawValue {
-                        return callback(nil, OktaOidcError.userCancelledAuthorizationFlow)
-                    } else {
-                        return callback(nil, OktaOidcError.APIError("Authorization Error: \(error.localizedDescription)"))
-                    }
+                if let authResponse = authorizationResponse {
+                    callback(authResponse, nil)
+                    return
                 }
-                callback(authResponse, nil)
+                
+                guard let error = error else {
+                    callback(nil, OktaOidcError.APIError("Authorization Error: No authorization response"))
+                    return
+                }
+                
+                if (error as NSError).code == OKTErrorCode.userCanceledAuthorizationFlow.rawValue {
+                    callback(nil, OktaOidcError.userCancelledAuthorizationFlow)
+                    return
+                }
+                
+                return callback(nil, OktaOidcError.APIError("Authorization Error: \(error.localizedDescription)"))
             }
             self.userAgentSession = userAgentSession
         }

--- a/Sources/OktaOidc/Common/Internal/Tasks/OktaOidcTask.swift
+++ b/Sources/OktaOidc/Common/Internal/Tasks/OktaOidcTask.swift
@@ -39,8 +39,7 @@ class OktaOidcTask {
 
             callback(OKTServiceConfiguration(discoveryDocument: oidConfig), nil)
         }, onError: { error in
-            let responseError = "Configuration Error: Cannot retrieve the discovery configuration. \(error.localizedDescription)."
-            callback(nil, OktaOidcError.APIError(responseError))
+            callback(nil, error)
         })
     }
 }

--- a/Sources/OktaOidc/Common/Internal/Tasks/OktaOidcTask.swift
+++ b/Sources/OktaOidc/Common/Internal/Tasks/OktaOidcTask.swift
@@ -39,9 +39,7 @@ class OktaOidcTask {
 
             callback(OKTServiceConfiguration(discoveryDocument: oidConfig), nil)
         }, onError: { error in
-            let responseError =
-                "Error returning discovery document: \(error.localizedDescription). Please" +
-                " check your PList configuration"
+            let responseError = "Configuration Error: Cannot retrieve the discovery configuration. \(error.localizedDescription)."
             callback(nil, OktaOidcError.APIError(responseError))
         })
     }

--- a/Sources/OktaOidc/Common/OktaOidcError.swift
+++ b/Sources/OktaOidc/Common/OktaOidcError.swift
@@ -14,7 +14,7 @@ import Foundation
 
 public enum OktaOidcError: Error {
     
-    case api(message: String, underlineError: Error?)
+    case api(message: String, underlyingError: Error?)
     case errorFetchingFreshTokens(String)
     case JWTDecodeError
     case JWTValidationError(String)

--- a/Sources/OktaOidc/Common/OktaOidcError.swift
+++ b/Sources/OktaOidc/Common/OktaOidcError.swift
@@ -13,7 +13,8 @@
 import Foundation
 
 public enum OktaOidcError: Error {
-    case APIError(String)
+    
+    case api(message: String, underlineError: Error?)
     case errorFetchingFreshTokens(String)
     case JWTDecodeError
     case JWTValidationError(String)
@@ -39,8 +40,8 @@ public enum OktaOidcError: Error {
 extension OktaOidcError: LocalizedError {
     public var errorDescription: String? {
         switch self {
-        case .APIError(error: let error):
-            return NSLocalizedString(error, comment: "")
+        case let .api(message, _):
+            return NSLocalizedString(message, comment: "")
         case .errorFetchingFreshTokens(error: let error):
             return NSLocalizedString("Error fetching fresh tokens: \(error)", comment: "")
         case .JWTDecodeError:

--- a/Sources/OktaOidc/Common/OktaOidcError.swift
+++ b/Sources/OktaOidc/Common/OktaOidcError.swift
@@ -14,10 +14,16 @@ import Foundation
 
 public enum OktaOidcError: CustomNSError {
     
+    /// See [RFC6749 Error Response](https://tools.ietf.org/html/rfc6749#section-4.1.2.1).
+    case authorization(error: String, description: String?)
+    
     case api(message: String, underlyingError: Error?)
+    case unexpectedAuthCodeResponse(statusCode: Int)
     case errorFetchingFreshTokens(String)
-    case JWTDecodeError
     case JWTValidationError(String)
+    case redirectServerError(String)
+    case JWTDecodeError
+    case noLocationHeader
     case missingConfigurationValues
     case noBearerToken
     case noDiscoveryEndpoint
@@ -31,16 +37,14 @@ public enum OktaOidcError: CustomNSError {
     case noUserInfoEndpoint
     case parseFailure
     case missingIdToken
-    case unexpectedAuthCodeResponse(statusCode: Int)
     case userCancelledAuthorizationFlow
     case unableToGetAuthCode
-    case redirectServerError(String)
-    /// See [RFC6749 Error Response](https://tools.ietf.org/html/rfc6749#section-4.1.2.1).
-    case authorization(error: String, description: String?)
-    case noLocationHeader
     
     public static var errorDomain: String = "\(Self.self)"
     
+    /// Most of errors returns the general error code.
+    /// Error like `api`, `unexpectedAuthCodeResponse` return specific error code.
+    /// `api` returns the general error code if `underlyingError` is absent. 
     public static let generalErrorCode = -1012009
     
     public var errorCode: Int {
@@ -66,6 +70,12 @@ public enum OktaOidcError: CustomNSError {
         default:
             return result
         }
+    }
+}
+
+extension OktaOidcError: Equatable {
+    public static func == (lhs: OktaOidcError, rhs: OktaOidcError) -> Bool {
+        lhs as NSError == rhs as NSError
     }
 }
 

--- a/Sources/OktaOidc/Common/OktaOidcError.swift
+++ b/Sources/OktaOidc/Common/OktaOidcError.swift
@@ -35,6 +35,9 @@ public enum OktaOidcError: Error {
     case userCancelledAuthorizationFlow
     case unableToGetAuthCode
     case redirectServerError(String)
+    /// See [RFC6749 Error Response](https://tools.ietf.org/html/rfc6749#section-4.1.2.1).
+    case authorization(error: String, description: String?)
+    case noLocationHeader
 }
 
 extension OktaOidcError: LocalizedError {
@@ -83,6 +86,10 @@ extension OktaOidcError: LocalizedError {
             return NSLocalizedString("Unable to get authorization code.", comment: "")
         case .redirectServerError(error: let error):
             return NSLocalizedString(error, comment: "")
+        case let .authorization(error, description):
+            return NSLocalizedString("The authorization request failed due to \(error): \(description ?? "")", comment: "")
+        case .noLocationHeader:
+            return NSLocalizedString("Unable to get location header.", comment: "")
         }
     }
 }

--- a/Sources/OktaOidc/Common/OktaOidcError.swift
+++ b/Sources/OktaOidc/Common/OktaOidcError.swift
@@ -30,7 +30,7 @@ public enum OktaOidcError: Error {
     case noUserInfoEndpoint
     case parseFailure
     case missingIdToken
-    case unexpectedAuthCodeResponse
+    case unexpectedAuthCodeResponse(statusCode: Int)
     case userCancelledAuthorizationFlow
     case unableToGetAuthCode
     case redirectServerError(String)
@@ -74,8 +74,8 @@ extension OktaOidcError: LocalizedError {
             return NSLocalizedString("Failed to parse and/or convert object.", comment: "")
         case .missingIdToken:
             return NSLocalizedString("ID token needed to fulfill this operation.", comment: "")
-        case .unexpectedAuthCodeResponse:
-            return NSLocalizedString("Unexpected response format while retrieving authorization code.", comment: "")
+        case .unexpectedAuthCodeResponse(let statusCode):
+            return NSLocalizedString("Unexpected response format while retrieving authorization code. Status code: \(statusCode)", comment: "")
         case .userCancelledAuthorizationFlow:
             return NSLocalizedString("User cancelled current session", comment: "")
         case .unableToGetAuthCode:

--- a/Sources/OktaOidc/Common/OktaOidcError.swift
+++ b/Sources/OktaOidc/Common/OktaOidcError.swift
@@ -45,7 +45,7 @@ public enum OktaOidcError: CustomNSError {
     /// Most of errors returns the general error code.
     /// Error like `api`, `unexpectedAuthCodeResponse` return specific error code.
     /// `api` returns the general error code if `underlyingError` is absent. 
-    public static let generalErrorCode = -1012009
+    private static let generalErrorCode = -1012009
     
     public var errorCode: Int {
         switch self {

--- a/Tests/OktaOidcTests/OktaOidcDiscoveryTaskTests.swift
+++ b/Tests/OktaOidcTests/OktaOidcDiscoveryTaskTests.swift
@@ -48,7 +48,7 @@ class OktaOidcDiscoveryTaskTests: XCTestCase {
     }
     
     func testRunApiError() {
-        apiMock.configure(error: OktaOidcError.api(message: "Test Error", underlineError: nil))
+        apiMock.configure(error: OktaOidcError.api(message: "Test Error", underlyingError: nil))
         
         runAndWaitDiscovery(config: validConfig) { oidConfig, error in
             XCTAssertNil(oidConfig)

--- a/Tests/OktaOidcTests/OktaOidcDiscoveryTaskTests.swift
+++ b/Tests/OktaOidcTests/OktaOidcDiscoveryTaskTests.swift
@@ -48,14 +48,12 @@ class OktaOidcDiscoveryTaskTests: XCTestCase {
     }
     
     func testRunApiError() {
-        apiMock.configure(error: OktaOidcError.api(message: "Test Error", underlyingError: nil))
+        let mockError = OktaOidcError.api(message: "Test Error", underlyingError: nil)
+        apiMock.configure(error: mockError)
         
         runAndWaitDiscovery(config: validConfig) { oidConfig, error in
             XCTAssertNil(oidConfig)
-            XCTAssertEqual(
-                "Error returning discovery document: Test Error. Please check your PList configuration",
-                error?.localizedDescription
-            )
+            XCTAssertEqual(mockError, error as OktaOidcError?)
         }
     }
     

--- a/Tests/OktaOidcTests/OktaOidcDiscoveryTaskTests.swift
+++ b/Tests/OktaOidcTests/OktaOidcDiscoveryTaskTests.swift
@@ -48,7 +48,7 @@ class OktaOidcDiscoveryTaskTests: XCTestCase {
     }
     
     func testRunApiError() {
-        apiMock.configure(error: OktaOidcError.APIError("Test Error"))
+        apiMock.configure(error: OktaOidcError.api(message: "Test Error", underlineError: nil))
         
         runAndWaitDiscovery(config: validConfig) { oidConfig, error in
             XCTAssertNil(oidConfig)

--- a/Tests/OktaOidcTests/OktaOidcEndpointTests.swift
+++ b/Tests/OktaOidcTests/OktaOidcEndpointTests.swift
@@ -126,18 +126,18 @@ class OktaOidcEndpointTests: XCTestCase {
 
     func testNoEndpointError() {
         XCTAssertEqual(
-            OktaOidcError.noIntrospectionEndpoint.localizedDescription,
-            OktaOidcEndpoint.introspection.noEndpointError.localizedDescription
+            OktaOidcError.noIntrospectionEndpoint,
+            OktaOidcEndpoint.introspection.noEndpointError
         )
         
         XCTAssertEqual(
-            OktaOidcError.noRevocationEndpoint.localizedDescription,
-            OktaOidcEndpoint.revocation.noEndpointError.localizedDescription
+            OktaOidcError.noRevocationEndpoint,
+            OktaOidcEndpoint.revocation.noEndpointError
         )
         
         XCTAssertEqual(
-            OktaOidcError.noUserInfoEndpoint.localizedDescription,
-            OktaOidcEndpoint.userInfo.noEndpointError.localizedDescription
+            OktaOidcError.noUserInfoEndpoint,
+            OktaOidcEndpoint.userInfo.noEndpointError
         )
     }
 

--- a/Tests/OktaOidcTests/OktaOidcErrorTests.swift
+++ b/Tests/OktaOidcTests/OktaOidcErrorTests.swift
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+// swiftlint:disable force_try
+// swiftlint:disable force_cast
+// swiftlint:disable force_unwrapping
+
+@testable import OktaOidc
+import XCTest
+
+#if SWIFT_PACKAGE
+@testable import TestCommon
+#endif
+
+final class OktaOidcErrorTests: XCTestCase {
+    
+    func testGeneralOidcError() {
+        let error = OktaOidcError.JWTDecodeError as NSError
+
+        XCTAssertEqual(error.code, OktaOidcError.generalErrorCode)
+        XCTAssertEqual(error.domain, OktaOidcError.errorDomain)
+        XCTAssertEqual(error.userInfo[NSLocalizedDescriptionKey] as! String, error.localizedDescription)
+        XCTAssertNil(error.userInfo[NSUnderlyingErrorKey] as? NSError)
+        
+        if #available(iOS 14.5, *) {
+            XCTAssertTrue(error.underlyingErrors.isEmpty)
+        }
+    }
+    
+    func testApiError() {
+        let underlyingError = NSError(domain: NSURLErrorDomain,
+                                      code: NSURLErrorNetworkConnectionLost,
+                                      userInfo: [NSLocalizedDescriptionKey: "Localization error description"])
+        let error = OktaOidcError.api(message: "Mock error", underlyingError: underlyingError) as NSError
+        
+        XCTAssertEqual(error.domain, OktaOidcError.errorDomain)
+        XCTAssertEqual(error.code, underlyingError.code)
+        XCTAssertEqual(error.userInfo[NSUnderlyingErrorKey] as! NSError, underlyingError)
+        XCTAssertEqual(error.userInfo[NSLocalizedDescriptionKey] as! String, error.localizedDescription)
+        
+        if #available(iOS 14.5, *) {
+            XCTAssertEqual(error.underlyingErrors.first! as NSError, underlyingError)
+        }
+    }
+    
+    func testApiErrorWithoutUnderlyingError() {
+        let error = OktaOidcError.api(message: "Mock error", underlyingError: nil) as NSError
+        
+        XCTAssertEqual(error.domain, OktaOidcError.errorDomain)
+        XCTAssertEqual(error.code, OktaOidcError.generalErrorCode)
+        XCTAssertNil(error.userInfo[NSUnderlyingErrorKey] as? NSError)
+        XCTAssertEqual(error.userInfo[NSLocalizedDescriptionKey] as! String, error.localizedDescription)
+        
+        if #available(iOS 14.5, *) {
+            XCTAssertTrue(error.underlyingErrors.isEmpty)
+        }
+    }
+    
+    func testAuthCodeResponseError() {
+        let error = OktaOidcError.unexpectedAuthCodeResponse(statusCode: 404) as NSError
+        
+        XCTAssertEqual(error.domain, OktaOidcError.errorDomain)
+        XCTAssertEqual(error.code, 404)
+        XCTAssertNil(error.userInfo[NSUnderlyingErrorKey] as? NSError)
+        XCTAssertEqual(error.userInfo[NSLocalizedDescriptionKey] as! String, error.localizedDescription)
+    }
+    
+    func testErrorsEquatability() {
+        // unexpectedAuthCodeResponse
+        let lhsAuthCodeResponse = OktaOidcError.unexpectedAuthCodeResponse(statusCode: NSURLErrorCannotLoadFromNetwork)
+        let rhsAuthCodeResponse = OktaOidcError.unexpectedAuthCodeResponse(statusCode: NSURLErrorCannotLoadFromNetwork)
+        
+        XCTAssertEqual(lhsAuthCodeResponse, rhsAuthCodeResponse)
+        XCTAssertEqual(lhsAuthCodeResponse as NSError, rhsAuthCodeResponse as NSError)
+        XCTAssertNotEqual(lhsAuthCodeResponse, .unexpectedAuthCodeResponse(statusCode: 123))
+        XCTAssertNotEqual(lhsAuthCodeResponse, .noPListGiven)
+        
+        // api
+        let underlyingError = NSError(domain: NSURLErrorDomain,
+                                      code: NSURLErrorNetworkConnectionLost,
+                                      userInfo: [NSLocalizedDescriptionKey: "Localization error description"])
+        let lhsApiError = OktaOidcError.api(message: "Mock error", underlyingError: underlyingError)
+        let rhsApiError = OktaOidcError.api(message: "Mock error", underlyingError: underlyingError)
+        
+        XCTAssertEqual(lhsApiError, rhsApiError)
+        XCTAssertEqual(lhsApiError as NSError, rhsApiError as NSError)
+        XCTAssertNotEqual(lhsApiError, .api(message: "Mock error", underlyingError: nil))
+        XCTAssertNotEqual(lhsApiError, .JWTDecodeError)
+        
+        // authorization
+        let rhsAuthorization = OktaOidcError.authorization(error: "Error", description: "Localized Description")
+        let lhsAuthorization = OktaOidcError.authorization(error: "Error", description: "Localized Description")
+        
+        XCTAssertEqual(rhsAuthorization, lhsAuthorization)
+        XCTAssertEqual(rhsAuthorization as NSError, lhsAuthorization as NSError)
+        XCTAssertNotEqual(rhsAuthorization, .authorization(error: "Error", description: "Localized Description (2)"))
+        XCTAssertNotEqual(.missingConfigurationValues, lhsAuthorization)
+        
+        // errorFetchingFreshTokens
+        let rhsFetchingFreshTokens = OktaOidcError.errorFetchingFreshTokens("Fetch Error")
+        let lhsFetchingFreshTokens = OktaOidcError.errorFetchingFreshTokens("Fetch Error")
+        XCTAssertEqual(rhsFetchingFreshTokens, lhsFetchingFreshTokens)
+        XCTAssertEqual(rhsFetchingFreshTokens as NSError, lhsFetchingFreshTokens as NSError)
+        XCTAssertNotEqual(rhsFetchingFreshTokens, .errorFetchingFreshTokens("Fetch Error (2)"))
+        XCTAssertNotEqual(.noBearerToken, rhsFetchingFreshTokens)
+    }
+}

--- a/Tests/OktaOidcTests/OktaOidcStateManagerTests.swift
+++ b/Tests/OktaOidcTests/OktaOidcStateManagerTests.swift
@@ -78,14 +78,14 @@ class OktaOidcStateManagerTests: XCTestCase {
     
     func testIntrospectFailed() {
         // Mock REST API calls
-        apiMock.configure(error: .APIError("Test Error"))
+        apiMock.configure(error: .api(message: "Test Error", underlineError: nil))
         
         let introspectExpectation = expectation(description: "Will fail with error.")
         
         authStateManager.introspect(token: authStateManager.accessToken) { payload, error in
             XCTAssertNil(payload)
             XCTAssertEqual(
-                OktaOidcError.APIError("Test Error").localizedDescription,
+                OktaOidcError.api(message: "Test Error", underlineError: nil).localizedDescription,
                 error?.localizedDescription
             )
             introspectExpectation.fulfill()
@@ -112,7 +112,7 @@ class OktaOidcStateManagerTests: XCTestCase {
 
     func testRevokeNoBearerToken() {
         // Mock REST API calls
-        apiMock.configure(error: .APIError("Test Error"))
+        apiMock.configure(error: .api(message: "Test Error", underlineError: nil))
         
         let revokeExpectation = expectation(description: "Will fail with error.")
         
@@ -131,14 +131,14 @@ class OktaOidcStateManagerTests: XCTestCase {
     
     func testRevokeFailed() {
         // Mock REST API calls
-        apiMock.configure(error: .APIError("Test Error"))
+        apiMock.configure(error: .api(message: "Test Error", underlineError: nil))
         
         let revokeExpectation = expectation(description: "Will fail with error.")
         
         authStateManager.revoke(authStateManager.accessToken) { isRevoked, error in
             XCTAssertFalse(isRevoked)
             XCTAssertEqual(
-                OktaOidcError.APIError("Test Error").localizedDescription,
+                OktaOidcError.api(message: "Test Error", underlineError: nil).localizedDescription,
                 error?.localizedDescription
             )
             
@@ -166,14 +166,14 @@ class OktaOidcStateManagerTests: XCTestCase {
     
     func testGetUserFailed() {
         // Mock REST API calls
-        apiMock.configure(error: .APIError("Test Error"))
+        apiMock.configure(error: .api(message: "Test Error", underlineError: nil))
         
         let userInfoExpectation = expectation(description: "Will fail with error.")
         
         authStateManager.getUser { payload, error in
             XCTAssertNil(payload)
             XCTAssertEqual(
-                OktaOidcError.APIError("Test Error").localizedDescription,
+                OktaOidcError.api(message: "Test Error", underlineError: nil).localizedDescription,
                 error?.localizedDescription
             )
             

--- a/Tests/OktaOidcTests/OktaOidcStateManagerTests.swift
+++ b/Tests/OktaOidcTests/OktaOidcStateManagerTests.swift
@@ -78,14 +78,14 @@ class OktaOidcStateManagerTests: XCTestCase {
     
     func testIntrospectFailed() {
         // Mock REST API calls
-        apiMock.configure(error: .api(message: "Test Error", underlineError: nil))
+        apiMock.configure(error: .api(message: "Test Error", underlyingError: nil))
         
         let introspectExpectation = expectation(description: "Will fail with error.")
         
         authStateManager.introspect(token: authStateManager.accessToken) { payload, error in
             XCTAssertNil(payload)
             XCTAssertEqual(
-                OktaOidcError.api(message: "Test Error", underlineError: nil).localizedDescription,
+                OktaOidcError.api(message: "Test Error", underlyingError: nil).localizedDescription,
                 error?.localizedDescription
             )
             introspectExpectation.fulfill()
@@ -112,7 +112,7 @@ class OktaOidcStateManagerTests: XCTestCase {
 
     func testRevokeNoBearerToken() {
         // Mock REST API calls
-        apiMock.configure(error: .api(message: "Test Error", underlineError: nil))
+        apiMock.configure(error: .api(message: "Test Error", underlyingError: nil))
         
         let revokeExpectation = expectation(description: "Will fail with error.")
         
@@ -131,14 +131,14 @@ class OktaOidcStateManagerTests: XCTestCase {
     
     func testRevokeFailed() {
         // Mock REST API calls
-        apiMock.configure(error: .api(message: "Test Error", underlineError: nil))
+        apiMock.configure(error: .api(message: "Test Error", underlyingError: nil))
         
         let revokeExpectation = expectation(description: "Will fail with error.")
         
         authStateManager.revoke(authStateManager.accessToken) { isRevoked, error in
             XCTAssertFalse(isRevoked)
             XCTAssertEqual(
-                OktaOidcError.api(message: "Test Error", underlineError: nil).localizedDescription,
+                OktaOidcError.api(message: "Test Error", underlyingError: nil).localizedDescription,
                 error?.localizedDescription
             )
             
@@ -166,14 +166,14 @@ class OktaOidcStateManagerTests: XCTestCase {
     
     func testGetUserFailed() {
         // Mock REST API calls
-        apiMock.configure(error: .api(message: "Test Error", underlineError: nil))
+        apiMock.configure(error: .api(message: "Test Error", underlyingError: nil))
         
         let userInfoExpectation = expectation(description: "Will fail with error.")
         
         authStateManager.getUser { payload, error in
             XCTAssertNil(payload)
             XCTAssertEqual(
-                OktaOidcError.api(message: "Test Error", underlineError: nil).localizedDescription,
+                OktaOidcError.api(message: "Test Error", underlyingError: nil).localizedDescription,
                 error?.localizedDescription
             )
             

--- a/Tests/OktaOidcTests/OktaOidcStateManagerTests.swift
+++ b/Tests/OktaOidcTests/OktaOidcStateManagerTests.swift
@@ -78,16 +78,19 @@ class OktaOidcStateManagerTests: XCTestCase {
     
     func testIntrospectFailed() {
         // Mock REST API calls
-        apiMock.configure(error: .api(message: "Test Error", underlyingError: nil))
+        let underlyingError = NSError(domain: NSURLErrorDomain,
+                                      code: NSURLErrorNetworkConnectionLost,
+                                      userInfo: [NSLocalizedDescriptionKey: "Localization error description"])
+        let mockError = OktaOidcError.api(message: "Test Error", underlyingError: underlyingError)
+        apiMock.configure(error: mockError)
         
         let introspectExpectation = expectation(description: "Will fail with error.")
         
         authStateManager.introspect(token: authStateManager.accessToken) { payload, error in
             XCTAssertNil(payload)
-            XCTAssertEqual(
-                OktaOidcError.api(message: "Test Error", underlyingError: nil).localizedDescription,
-                error?.localizedDescription
-            )
+            
+            XCTAssertEqual(mockError, error as? OktaOidcError)
+            
             introspectExpectation.fulfill()
         }
         
@@ -112,16 +115,19 @@ class OktaOidcStateManagerTests: XCTestCase {
 
     func testRevokeNoBearerToken() {
         // Mock REST API calls
-        apiMock.configure(error: .api(message: "Test Error", underlyingError: nil))
+        let underlyingError = NSError(domain: NSURLErrorDomain,
+                                      code: NSURLErrorNetworkConnectionLost,
+                                      userInfo: [NSLocalizedDescriptionKey: "Localization error description"])
+        
+        let mockError = OktaOidcError.api(message: "Test Error", underlyingError: underlyingError)
+        apiMock.configure(error: mockError)
         
         let revokeExpectation = expectation(description: "Will fail with error.")
         
         authStateManager.revoke(nil) { isRevoked, error in
             XCTAssertFalse(isRevoked)
-            XCTAssertEqual(
-                OktaOidcError.noBearerToken.localizedDescription,
-                error?.localizedDescription
-            )
+            
+            XCTAssertEqual(OktaOidcError.noBearerToken, error as? OktaOidcError)
             
             revokeExpectation.fulfill()
         }
@@ -131,16 +137,18 @@ class OktaOidcStateManagerTests: XCTestCase {
     
     func testRevokeFailed() {
         // Mock REST API calls
-        apiMock.configure(error: .api(message: "Test Error", underlyingError: nil))
+        let underlyingError = NSError(domain: NSURLErrorDomain,
+                                      code: NSURLErrorNetworkConnectionLost,
+                                      userInfo: [NSLocalizedDescriptionKey: "Localization error description"])
+        
+        let mockError = OktaOidcError.api(message: "Test Error", underlyingError: underlyingError)
+        apiMock.configure(error: mockError)
         
         let revokeExpectation = expectation(description: "Will fail with error.")
         
         authStateManager.revoke(authStateManager.accessToken) { isRevoked, error in
             XCTAssertFalse(isRevoked)
-            XCTAssertEqual(
-                OktaOidcError.api(message: "Test Error", underlyingError: nil).localizedDescription,
-                error?.localizedDescription
-            )
+            XCTAssertEqual(mockError, error as? OktaOidcError)
             
             revokeExpectation.fulfill()
         }
@@ -166,16 +174,18 @@ class OktaOidcStateManagerTests: XCTestCase {
     
     func testGetUserFailed() {
         // Mock REST API calls
-        apiMock.configure(error: .api(message: "Test Error", underlyingError: nil))
+        let underlyingError = NSError(domain: NSURLErrorDomain,
+                                      code: NSURLErrorNetworkConnectionLost,
+                                      userInfo: [NSLocalizedDescriptionKey: "Localization error description"])
+        
+        let mockError = OktaOidcError.api(message: "Test Error", underlyingError: underlyingError)
+        apiMock.configure(error: mockError)
         
         let userInfoExpectation = expectation(description: "Will fail with error.")
         
         authStateManager.getUser { payload, error in
             XCTAssertNil(payload)
-            XCTAssertEqual(
-                OktaOidcError.api(message: "Test Error", underlyingError: nil).localizedDescription,
-                error?.localizedDescription
-            )
+            XCTAssertEqual(mockError, error as? OktaOidcError)
             
             userInfoExpectation.fulfill()
         }
@@ -192,8 +202,8 @@ class OktaOidcStateManagerTests: XCTestCase {
         authStateManager.getUser { payload, error in
             XCTAssertNil(payload)
             XCTAssertEqual(
-                OktaOidcError.noBearerToken.localizedDescription,
-                error?.localizedDescription
+                OktaOidcError.noBearerToken,
+                error as? OktaOidcError
             )
             
             userInfoExpectation.fulfill()

--- a/okta-oidc.xcodeproj/project.pbxproj
+++ b/okta-oidc.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		92AF826326209E1C004D157D /* OktaOidcHttpApiProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922628782617553E002F6BC4 /* OktaOidcHttpApiProtocol.swift */; };
 		92B62A2D25C41E59002CE64F /* OKTTokensAuthMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B62A2C25C41E59002CE64F /* OKTTokensAuthMock.swift */; };
 		92B62A2E25C41E59002CE64F /* OKTTokensAuthMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B62A2C25C41E59002CE64F /* OKTTokensAuthMock.swift */; };
+		92DB056B2751129E00B3714F /* OktaOidcErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DB05692751125C00B3714F /* OktaOidcErrorTests.swift */; };
 		9601C34C256DD14800C084F5 /* OktaRedirectServerConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A167889D2433C7B500D1651D /* OktaRedirectServerConfigurationTests.swift */; };
 		9601C34D256DD14800C084F5 /* OktaOidcBrowserTaskMACTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A167889F2433D0DB00D1651D /* OktaOidcBrowserTaskMACTests.swift */; };
 		9601C34E256DD14800C084F5 /* OktaOidcSignOutHandlerMACTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16788A62435250700D1651D /* OktaOidcSignOutHandlerMACTests.swift */; };
@@ -377,6 +378,7 @@
 		922628782617553E002F6BC4 /* OktaOidcHttpApiProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaOidcHttpApiProtocol.swift; sourceTree = "<group>"; };
 		922628DA261B1F90002F6BC4 /* XCUIElement+Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Utils.swift"; sourceTree = "<group>"; };
 		92B62A2C25C41E59002CE64F /* OKTTokensAuthMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKTTokensAuthMock.swift; sourceTree = "<group>"; };
+		92DB05692751125C00B3714F /* OktaOidcErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OktaOidcErrorTests.swift; sourceTree = "<group>"; };
 		960961F925672EC40077978A /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		9671A102256F153900D0B03F /* OktaOidcBrowserProtocolIOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OktaOidcBrowserProtocolIOS.swift; path = Internal/OktaOidcBrowserProtocolIOS.swift; sourceTree = "<group>"; };
 		9671A103256F153900D0B03F /* OktaOidc+BrowserIOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OktaOidc+BrowserIOS.swift"; sourceTree = "<group>"; };
@@ -598,9 +600,9 @@
 				2F32CA1F229D38D4003A6768 /* Products */,
 				2F32CBD2229D42D0003A6768 /* Frameworks */,
 			);
-			indentWidth = 2;
+			indentWidth = 4;
 			sourceTree = "<group>";
-			tabWidth = 2;
+			tabWidth = 4;
 		};
 		2F32CA1F229D38D4003A6768 /* Products */ = {
 			isa = PBXGroup;
@@ -784,6 +786,7 @@
 		A16788B72436AA2C00D1651D /* OktaOidcTests */ = {
 			isa = PBXGroup;
 			children = (
+				92DB05692751125C00B3714F /* OktaOidcErrorTests.swift */,
 				2F32CC09229D4CF8003A6768 /* OktaOidcTests.swift */,
 				2F32CC0A229D4CF8003A6768 /* OktaOidcStateManagerTests.swift */,
 				2F32CBE6229D4CF8003A6768 /* OktaOidcEndpointTests.swift */,
@@ -1432,6 +1435,7 @@
 				DEBFB8E42507A7C500A27026 /* OIDAuthorizationServiceRequestDelegateTests.swift in Sources */,
 				9601C371256DD25900C084F5 /* OktaOidcBrowserTaskMacMock.swift in Sources */,
 				2F32CC3C229D4D11003A6768 /* OktaOidcApiMock.swift in Sources */,
+				92DB056B2751129E00B3714F /* OktaOidcErrorTests.swift in Sources */,
 				A17E3A162358FA3300837873 /* OKTRPProfileCode.m in Sources */,
 				A17E3A102358FA3200837873 /* OKTAuthorizationResponseTests.m in Sources */,
 				A17E3A122358FA3300837873 /* OKTURLQueryComponentTestsIOS7.m in Sources */,


### PR DESCRIPTION
### Problem Analysis (Technical)
The error handling is not convenient in our SDK. It throws general `APIError` but doesn't provide additional error info where it may be helpful for better app UX.

### Solution (Technical)
Minimal changes to keep backward-compatibility and minimal customer' code changes. In general, error handling in the SDK must be refreshed. 
Refactoring `APIError` and improved somewhere error messages. 

### Affected Components
`OktaOidcError`

### Steps to reproduce:
[OKTA-448284](https://oktainc.atlassian.net/browse/OKTA-448284)

### Tests
Will be added soon. 