### PR TITLE
Return a specific error code when we are  not able to launch default …

### DIFF
--- a/Sources/OktaOidc/Common/Internal/Tasks/OktaOidcBrowserTask.swift
+++ b/Sources/OktaOidc/Common/Internal/Tasks/OktaOidcBrowserTask.swift
@@ -63,6 +63,11 @@ class OktaOidcBrowserTask: OktaOidcTask {
                     callback(nil, OktaOidcError.userCancelledAuthorizationFlow)
                     return
                 }
+
+                if (error as NSError).code == OKTErrorCode.browserOpenError.rawValue {
+                    callback(nil, OktaOidcError.unableToOpenBrowser)
+                    return
+                }
                 
                 return callback(nil, OktaOidcError.api(message: "Authorization Error: \(error.localizedDescription)", underlyingError: error))
             }

--- a/Sources/OktaOidc/Common/OktaOidcError.swift
+++ b/Sources/OktaOidc/Common/OktaOidcError.swift
@@ -39,6 +39,7 @@ public enum OktaOidcError: CustomNSError {
     case missingIdToken
     case userCancelledAuthorizationFlow
     case unableToGetAuthCode
+    case unableToOpenBrowser // macOS specific
     
     public static var errorDomain: String = "\(Self.self)"
     
@@ -129,6 +130,9 @@ extension OktaOidcError: LocalizedError {
             return NSLocalizedString("The authorization request failed due to \(error): \(description ?? "")", comment: "")
         case .noLocationHeader:
             return NSLocalizedString("Unable to get location header.", comment: "")
+        case .unableToOpenBrowser:
+            return NSLocalizedString("Error triggering authorization flow in default system browser. NSWorkspace.openURL returned false.", comment: "")
+
         }
     }
 }


### PR DESCRIPTION
Description:
…system browser for auth in macOS. 

Looks like sometimes we are not able to launch the system browser https://oktainc.atlassian.net/browse/OKTA-454838.
Exposing this error as a specific error code.

On the app side, I am planning to parse this error code and metrics to see how often we are seeing this. I am thinking this is a real edge case.
If it's prevalent then might think about even doing an embedded browser flow(hoping I don't have to do this).